### PR TITLE
feat: playback controls, skip surgeon, search, and dashboard

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -1,0 +1,19 @@
+# TODOs
+
+## Refactor Home.tsx to hooks
+- **What:** Replace `connect(mapStateToProps, dispatchToProps)` + `useSelector` mixed pattern with hooks-only (`useSelector`/`useDispatch`).
+- **Why:** Home.tsx is the only component mixing both Redux patterns. New code (Dashboard, Search) uses hooks exclusively — keeping Home.tsx inconsistent is a maintenance trap.
+- **Effort:** S
+- **Depends on:** Nothing
+
+## Generic 403 (premium required) handling in spotifyFetch
+- **What:** Add specific 403 detection in `spotifyFetch` that shows a clear "Spotify Premium required" message instead of a generic error toast.
+- **Why:** Free-tier users hitting any premium endpoint get an unhelpful generic error. Currently only playback controls will surface this, but it applies to any premium-gated endpoint.
+- **Effort:** S-M
+- **Depends on:** Nothing
+
+## Snapshot mismatch retry in batch track deletion
+- **What:** When deleting tracks in batches (Skip Surgeon, deduplication), detect snapshot_id mismatch errors, re-fetch the playlist snapshot, and retry the failed batch once.
+- **Why:** If a playlist is modified between fetch and delete (e.g., by another device or Spotify itself), some deletions silently fail. The user thinks tracks were removed but they weren't.
+- **Effort:** S
+- **Depends on:** Skip Surgeon implementation

--- a/src/actions/playback.ts
+++ b/src/actions/playback.ts
@@ -1,10 +1,13 @@
 import { Playback, Track, URI } from '~/types'
 import { makeActionCreator } from '~/utils/actionCreator'
 
+export type PlaybackCommand = 'play' | 'pause' | 'next' | 'previous' | 'shuffle' | 'repeat'
+
 export default {
 	updatePlayback: makeActionCreator<Playback>()('PLAYBACK_UPDATED'),
 	songSkipped: makeActionCreator<SpotifyApi.TrackObjectFull, SpotifyApi.ContextObject | null>()(
 		'PLAYBACK_SONG_SKIPPED'
 	),
-	resetSkips: makeActionCreator<Track['id'], URI>()('PLAYBACK_CLEAR_SKIPS')
+	resetSkips: makeActionCreator<Track['id'], URI>()('PLAYBACK_CLEAR_SKIPS'),
+	playbackControl: makeActionCreator<PlaybackCommand>()('PLAYBACK_CONTROL')
 }

--- a/src/components/layout/App.tsx
+++ b/src/components/layout/App.tsx
@@ -4,9 +4,11 @@ import { Route, Routes } from 'react-router'
 import 'static/app.svg'
 import 'static/app.webmanifest'
 import { __DEV__ } from '~/consts'
+import { Dashboard } from '~/pages/Dashboard'
 import PlaylistsManager from '~/pages/Home'
 import NotFound from '~/pages/NotFound'
 import PlaylistRoute from '~/pages/PlaylistRoute'
+import { Search } from '~/pages/Search'
 import { Skips } from '~/pages/Skips'
 import { TrackRoute } from '~/pages/TrackRoute'
 import '~/styles/main.scss'
@@ -34,6 +36,8 @@ const App: React.FC = () => {
 					{user ? (
 						<Routes>
 							<Route path="/" element={<PlaylistsManager />} />
+							<Route path="/dashboard" element={<Dashboard />} />
+							<Route path="/search" element={<Search />} />
 							<Route path="/skips" element={<Skips />} />
 							<Route path="/playlists/:id" element={<PlaylistRoute />} />
 							<Route path="/tracks/:id" element={<TrackRoute />} />

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -28,6 +28,12 @@ export const Header: React.FC<Props> = ({ user }) => (
 								<NavLink to="/">Playlists</NavLink>
 							</li>
 							<li>
+								<NavLink to="/dashboard">Dashboard</NavLink>
+							</li>
+							<li>
+								<NavLink to="/search">Search</NavLink>
+							</li>
+							<li>
 								<NavLink to="/skips">Skipped songs</NavLink>
 							</li>
 						</>

--- a/src/components/layout/NowPlaying.tsx
+++ b/src/components/layout/NowPlaying.tsx
@@ -26,7 +26,9 @@ export const NowPlaying: React.FC = () => {
 			}
 		}
 	}, [playback?.progress_ms, playback?.is_playing, playback?.item.duration_ms])
-	const comingSoon = Actions.createNotification({ message: 'Coming soon!', duration: 500 })
+
+	const control = (command: Parameters<typeof Actions.playbackControl>[0]) =>
+		dispatch(Actions.playbackControl(command))
 
 	return playback?.currently_playing_type == 'track' && song ? (
 		<div className="grid grid-rows-[1fr,1fr,auto] grid-cols-[auto,auto,auto,1fr,6fr,1fr,auto] px-2 py-3 gap-x-4 items-center">
@@ -35,7 +37,7 @@ export const NowPlaying: React.FC = () => {
 			</a>
 			<UriLink className="col-start-2 row-start-1 self-end ellipsis" object={song} />
 			<ArtistLinks artists={song.album.artists} className="col-start-2 row-start-2 self-start text-xs" />
-			<button onClick={_ => dispatch(comingSoon)} className="col-start-3 row-span-2" type="button" role="switch">
+			<button className="col-start-3 row-span-2" type="button" role="switch" title="Like (coming soon)">
 				<svg height="1em" viewBox="0 0 16 16" className="text-transparent hover:text-white">
 					<path fill="none" d="M0 0h16v16H0z"></path>
 					<path
@@ -45,17 +47,17 @@ export const NowPlaying: React.FC = () => {
 				</svg>
 			</button>
 			<div className="col-start-5 row-start-1 text-white flex justify-center items-center space-x-4 min-w-[20rem]">
-				<button onClick={_ => dispatch(comingSoon)} className={playback.shuffle_state ? 'text-green-500' : ''}>
+				<button onClick={_ => control('shuffle')} className={playback.shuffle_state ? 'text-green-500' : ''}>
 					<svg height="1em" viewBox="0 0 16 16">
 						<path d="M4.5 6.8l.7-.8C4.1 4.7 2.5 4 .9 4v1c1.3 0 2.6.6 3.5 1.6l.1.2zm7.5 4.7c-1.2 0-2.3-.5-3.2-1.3l-.6.8c1 1 2.4 1.5 3.8 1.5V14l3.5-2-3.5-2v1.5zm0-6V7l3.5-2L12 3v1.5c-1.6 0-3.2.7-4.2 2l-3.4 3.9c-.9 1-2.2 1.6-3.5 1.6v1c1.6 0 3.2-.7 4.2-2l3.4-3.9c.9-1 2.2-1.6 3.5-1.6z"></path>
 					</svg>
 				</button>
-				<button onClick={_ => dispatch(comingSoon)}>
+				<button onClick={_ => control('previous')}>
 					<svg height="1em" viewBox="0 0 16 16">
 						<path d="M13 2.5L5 7.119V3H3v10h2V8.881l8 4.619z"></path>
 					</svg>
 				</button>
-				<button onClick={_ => dispatch(comingSoon)} className="p-2 rounded-full">
+				<button onClick={_ => control(playback.is_playing ? 'pause' : 'play')} className="p-2 rounded-full">
 					{playback.is_playing ? (
 						<svg height="1em" viewBox="0 0 16 16">
 							<path fill="none" d="M0 0h16v16H0z"></path>
@@ -67,12 +69,12 @@ export const NowPlaying: React.FC = () => {
 						</svg>
 					)}
 				</button>
-				<button onClick={_ => dispatch(comingSoon)}>
+				<button onClick={_ => control('next')}>
 					<svg height="1em" viewBox="0 0 16 16">
 						<path d="M11 3v4.119L3 2.5v11l8-4.619V13h2V3z"></path>
 					</svg>
 				</button>
-				<button onClick={_ => dispatch(comingSoon)} className={playback.repeat_state ? 'text-green-500' : ''}>
+				<button onClick={_ => control('repeat')} className={playback.repeat_state !== 'off' ? 'text-green-500' : ''}>
 					<svg height="1em" viewBox="0 0 16 16">
 						<path d="M5.5 5H10v1.5l3.5-2-3.5-2V4H5.5C3 4 1 6 1 8.5c0 .6.1 1.2.4 1.8l.9-.5C2.1 9.4 2 9 2 8.5 2 6.6 3.6 5 5.5 5zm9.1 1.7l-.9.5c.2.4.3.8.3 1.3 0 1.9-1.6 3.5-3.5 3.5H6v-1.5l-3.5 2 3.5 2V13h4.5C13 13 15 11 15 8.5c0-.6-.1-1.2-.4-1.8z" />
 					</svg>

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,0 +1,169 @@
+import React, { useMemo } from 'react'
+import { useSelector } from 'react-redux'
+import { Link } from 'react-router-dom'
+import { State } from '~/types'
+import { Duration, SongCache, songEntriesToSongs, useFirebase } from '~/utils'
+
+export const Dashboard: React.FC = () => {
+	const playlists = useSelector((s: State) => s.playlists)
+	const user = useSelector((s: State) => s.user)
+	const plays = useFirebase(`users/${user?.uid}/plays/`) || {}
+	const skips = useFirebase(`users/${user?.uid}/skips/`) || {}
+
+	const stats = useMemo(() => {
+		const totalTracks = playlists.reduce((a, b) => a + b.tracks.total, 0)
+		const loadedPlaylists = playlists.filter(pl => pl.tracks.loaded === pl.tracks.total)
+		const tracks = loadedPlaylists.flatMap(pl => songEntriesToSongs(pl.tracks.items))
+		const totalDuration = tracks.reduce((a, b) => a + b.duration_ms, 0)
+
+		// Count duplicates (tracks appearing in multiple playlists)
+		const trackCounts = new Map<string, number>()
+		for (const pl of loadedPlaylists) {
+			for (const id of Object.keys(pl.tracks.items)) {
+				trackCounts.set(id, (trackCounts.get(id) || 0) + 1)
+			}
+		}
+		const duplicateCount = Array.from(trackCounts.values()).filter(c => c > 1).length
+
+		// Unique tracks
+		const uniqueTracks = trackCounts.size
+
+		// Skip stats per playlist
+		const playlistSkipRates = loadedPlaylists
+			.map(pl => {
+				const contextUri = pl.uri
+				const playlistSkips = skips[contextUri] || {}
+				const playlistPlays = plays[contextUri] || {}
+				const totalSkips = Object.values(playlistSkips).reduce<number>((a, b) => a + (Number(b) || 0), 0)
+				const totalPlays = Object.values(playlistPlays).reduce<number>((a, b) => a + (Number(b) || 0), 0)
+				const skipRate = totalPlays > 0 ? totalSkips / totalPlays : 0
+				return { name: pl.name, id: pl.id, skipRate, totalSkips, totalPlays }
+			})
+			.filter(pl => pl.totalPlays > 0)
+			.sort((a, b) => b.skipRate - a.skipRate)
+
+		// Most skipped tracks (aggregate across all playlists)
+		const trackSkips = new Map<string, number>()
+		for (const contextSkips of Object.values(skips)) {
+			if (typeof contextSkips !== 'object' || contextSkips === null) continue
+			for (const [trackId, count] of Object.entries(contextSkips)) {
+				trackSkips.set(trackId, (trackSkips.get(trackId) || 0) + (Number(count) || 0))
+			}
+		}
+		const mostSkipped = Array.from(trackSkips.entries())
+			.sort(([, a], [, b]) => b - a)
+			.slice(0, 10)
+
+		return {
+			totalPlaylists: playlists.length,
+			loadedPlaylists: loadedPlaylists.length,
+			totalTracks,
+			uniqueTracks,
+			totalDuration,
+			duplicateCount,
+			playlistSkipRates,
+			mostSkipped
+		}
+	}, [playlists, plays, skips])
+
+	if (!user) return null
+
+	return (
+		<div className="max-h-full grid grid-rows-[auto,1fr] grid-cols-1">
+			<header className="pt-4 px-4 space-y-4">
+				<h2 className="text-2xl">Library Dashboard</h2>
+
+				<div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+					<StatCard label="Playlists" value={stats.totalPlaylists} />
+					<StatCard label="Total Tracks" value={stats.totalTracks} />
+					<StatCard label="Unique Tracks" value={stats.uniqueTracks || '—'} />
+					<StatCard label="Total Duration" value={new Duration(stats.totalDuration).toString('hours')} />
+				</div>
+
+				{stats.duplicateCount > 0 && (
+					<div className="p-3 rounded border border-yellow-600 bg-yellow-900/20 text-yellow-200">
+						<strong>{stats.duplicateCount}</strong> track{stats.duplicateCount !== 1 && 's'} appear in multiple
+						playlists.{' '}
+						<Link to="/" className="underline">
+							Go to Playlists
+						</Link>{' '}
+						to deduplicate.
+					</div>
+				)}
+
+				<hr className="border-t-2 border-t-gray-300" />
+			</header>
+
+			<div className="overflow-y-scroll px-4 py-4 space-y-6">
+				{stats.playlistSkipRates.length > 0 && (
+					<section>
+						<h3 className="text-lg font-semibold mb-2">Highest Skip Rates</h3>
+						<table className="w-full max-w-2xl">
+							<thead>
+								<tr className="text-left text-gray-400 text-sm">
+									<th>Playlist</th>
+									<th className="text-right">Skip Rate</th>
+									<th className="text-right">Skips</th>
+									<th className="text-right">Plays</th>
+								</tr>
+							</thead>
+							<tbody>
+								{stats.playlistSkipRates.slice(0, 10).map(pl => (
+									<tr key={pl.id}>
+										<td>
+											<Link to={`/playlists/${pl.id}`} className="hover:underline">
+												{pl.name}
+											</Link>
+										</td>
+										<td className="text-right">{Math.round(pl.skipRate * 100)}%</td>
+										<td className="text-right text-gray-400">{pl.totalSkips}</td>
+										<td className="text-right text-gray-400">{pl.totalPlays}</td>
+									</tr>
+								))}
+							</tbody>
+						</table>
+						<Link to="/skips" className="text-sm text-gray-400 hover:underline mt-1 inline-block">
+							View all skipped songs →
+						</Link>
+					</section>
+				)}
+
+				{stats.mostSkipped.length > 0 && (
+					<section>
+						<h3 className="text-lg font-semibold mb-2">Most Skipped Tracks</h3>
+						<ol className="space-y-1 max-w-2xl">
+							{stats.mostSkipped.map(([trackId, count], i) => {
+								const track = SongCache.get(trackId)
+								return (
+									<li key={trackId} className="flex justify-between text-sm">
+										<span>
+											<span className="text-gray-500 mr-2">{i + 1}.</span>
+											<Link to={`/tracks/${trackId}`} className="hover:underline">
+												{track ? `${track.name} — ${track.artists.map(a => a.name).join(', ')}` : trackId}
+											</Link>
+										</span>
+										<span className="text-gray-400">{count} skip{count !== 1 && 's'}</span>
+									</li>
+								)
+							})}
+						</ol>
+					</section>
+				)}
+
+				{stats.loadedPlaylists < stats.totalPlaylists && (
+					<p className="text-sm text-gray-500">
+						{stats.loadedPlaylists} of {stats.totalPlaylists} playlists fully loaded. Stats will update as more
+						playlists are cached.
+					</p>
+				)}
+			</div>
+		</div>
+	)
+}
+
+const StatCard: React.FC<{ label: string; value: string | number }> = ({ label, value }) => (
+	<div className="p-3 rounded border border-gray-600 bg-gray-800/50">
+		<div className="text-2xl font-bold">{value}</div>
+		<div className="text-sm text-gray-400">{label}</div>
+	</div>
+)

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -7,10 +7,12 @@ import { Duration, SongCache, songEntriesToSongs, useFirebase } from '~/utils'
 export const Dashboard: React.FC = () => {
 	const playlists = useSelector((s: State) => s.playlists)
 	const user = useSelector((s: State) => s.user)
-	const plays = useFirebase(`users/${user?.uid}/plays/`) || {}
-	const skips = useFirebase(`users/${user?.uid}/skips/`) || {}
+	const rawPlays = useFirebase(`users/${user?.uid}/plays/`)
+	const rawSkips = useFirebase(`users/${user?.uid}/skips/`)
 
 	const stats = useMemo(() => {
+		const plays = rawPlays || {}
+		const skips = rawSkips || {}
 		const totalTracks = playlists.reduce((a, b) => a + b.tracks.total, 0)
 		const loadedPlaylists = playlists.filter(pl => pl.tracks.loaded === pl.tracks.total)
 		const tracks = loadedPlaylists.flatMap(pl => songEntriesToSongs(pl.tracks.items))
@@ -64,7 +66,7 @@ export const Dashboard: React.FC = () => {
 			playlistSkipRates,
 			mostSkipped
 		}
-	}, [playlists, plays, skips])
+	}, [playlists, rawPlays, rawSkips])
 
 	if (!user) return null
 

--- a/src/pages/Search.tsx
+++ b/src/pages/Search.tsx
@@ -1,6 +1,5 @@
 import React, { useMemo, useState } from 'react'
 import { useSelector } from 'react-redux'
-import { Link } from 'react-router-dom'
 import { ArtistLinks, UriLink } from '~/components/UriLink'
 import { State, Track } from '~/types'
 import { Duration, SongCache } from '~/utils'
@@ -44,7 +43,11 @@ export const Search: React.FC = () => {
 				<h2 className="text-2xl">Search Tracks</h2>
 				<input
 					type="text"
-					className="w-full max-w-lg px-3 py-2 rounded bg-gray-800 border-2 border-gray-600 hover:border-gray-400 focus:border-gray-300 outline-none"
+					className={[
+						'w-full max-w-lg px-3 py-2 rounded bg-gray-800',
+						'border-2 border-gray-600 hover:border-gray-400',
+						'focus:border-gray-300 outline-none'
+					].join(' ')}
 					placeholder="&#xF002; Search by track, artist, or album..."
 					value={query}
 					onChange={e => setQuery(e.target.value)}

--- a/src/pages/Search.tsx
+++ b/src/pages/Search.tsx
@@ -1,0 +1,108 @@
+import React, { useMemo, useState } from 'react'
+import { useSelector } from 'react-redux'
+import { Link } from 'react-router-dom'
+import { ArtistLinks, UriLink } from '~/components/UriLink'
+import { State, Track } from '~/types'
+import { Duration, SongCache } from '~/utils'
+
+type SearchResult = Track & {
+	playlistNames: string[]
+}
+
+export const Search: React.FC = () => {
+	const [query, setQuery] = useState('')
+	const playlists = useSelector((s: State) => s.playlists)
+
+	const results = useMemo(() => {
+		const trimmed = query.trim().toLowerCase()
+		if (trimmed.length < 2) return []
+
+		const matches: SearchResult[] = []
+		for (const track of SongCache.values()) {
+			const matchesName = track.name.toLowerCase().includes(trimmed)
+			const matchesArtist = track.artists.some(a => a.name.toLowerCase().includes(trimmed))
+			const matchesAlbum = track.album.name.toLowerCase().includes(trimmed)
+
+			if (matchesName || matchesArtist || matchesAlbum) {
+				// Find which playlists contain this track (on-demand scan per decision 4B)
+				const playlistNames = playlists
+					.filter(pl => pl.tracks.items[track.id] !== undefined)
+					.map(pl => pl.name)
+
+				matches.push({ ...track, playlistNames })
+			}
+
+			if (matches.length >= 200) break
+		}
+
+		return matches
+	}, [query, playlists])
+
+	return (
+		<div className="max-h-full grid grid-rows-[auto,1fr] grid-cols-1">
+			<header className="pt-4 px-4 space-y-2">
+				<h2 className="text-2xl">Search Tracks</h2>
+				<input
+					type="text"
+					className="w-full max-w-lg px-3 py-2 rounded bg-gray-800 border-2 border-gray-600 hover:border-gray-400 focus:border-gray-300 outline-none"
+					placeholder="&#xF002; Search by track, artist, or album..."
+					value={query}
+					onChange={e => setQuery(e.target.value)}
+					autoFocus
+				/>
+				{query.length >= 2 && (
+					<p className="text-sm text-gray-400">
+						{results.length >= 200 ? '200+ results' : `${results.length} result(s)`}
+						{results.length >= 200 && ' (showing first 200)'}
+					</p>
+				)}
+				<hr className="mt-2 border-t-2 border-t-gray-300" />
+			</header>
+
+			<div className="overflow-y-scroll px-4">
+				{query.length < 2 ? (
+					<p className="py-4 text-gray-400">Type at least 2 characters to search across all your playlists.</p>
+				) : results.length === 0 ? (
+					<p className="py-4 text-gray-400">No tracks found.</p>
+				) : (
+					<table className="playlists w-full">
+						<thead className="sticky top-0 bg-black">
+							<tr>
+								<th>Name</th>
+								<th>Artist</th>
+								<th>Album</th>
+								<th>Duration</th>
+								<th>In Playlists</th>
+							</tr>
+						</thead>
+						<tbody>
+							{results.map((track, index) => (
+								<tr key={track.id + index}>
+									<td>
+										<UriLink object={track} />
+									</td>
+									<td>
+										<ArtistLinks artists={track.artists} />
+									</td>
+									<td>
+										<UriLink object={track.album} />
+									</td>
+									<td>{new Duration(track.duration_ms).toMinutesString()}</td>
+									<td>
+										{track.playlistNames.length > 0 ? (
+											<span className="text-sm text-gray-300" title={track.playlistNames.join(', ')}>
+												{track.playlistNames.length} playlist{track.playlistNames.length !== 1 && 's'}
+											</span>
+										) : (
+											<span className="text-sm text-gray-500">—</span>
+										)}
+									</td>
+								</tr>
+							))}
+						</tbody>
+					</table>
+				)}
+			</div>
+		</div>
+	)
+}

--- a/src/pages/Skips/ByPlaylist.tsx
+++ b/src/pages/Skips/ByPlaylist.tsx
@@ -42,7 +42,11 @@ export const ByPlaylist: React.FC<Props> = ({ filterIds, skipData, countNonPlayl
 					<span className="row-span-2 justify-self-end">Total skips: {countSkips(playlist)}</span>
 					{playlist.owner?.id === user?.spotify.id && (
 						<button
-							className="row-span-2 justify-self-end opacity-60 hover:opacity-100 text-red-400 hover:text-red-300 text-sm px-2 py-1 border border-current rounded"
+							className={cn(
+								'row-span-2 justify-self-end text-sm px-2 py-1',
+								'opacity-60 hover:opacity-100 text-red-400',
+								'hover:text-red-300 border border-current rounded'
+							)}
 							title={`Remove all tracks with ${minSkips}+ skips from this playlist`}
 							onClick={_ => {
 								const skippedSongs = filterSongs(playlist)

--- a/src/pages/Skips/ByPlaylist.tsx
+++ b/src/pages/Skips/ByPlaylist.tsx
@@ -28,7 +28,7 @@ export const ByPlaylist: React.FC<Props> = ({ filterIds, skipData, countNonPlayl
 			<li key={playlist.uri + i} className={cn('py-2', { 'border-b-2 border-b-gray-300': i < length - 1 })}>
 				<div
 					className={cn(
-						'grid grid-rows-2 grid-cols-[auto,3fr,1fr] grid-flow-col items-center',
+						'grid grid-rows-2 grid-cols-[auto,3fr,auto,auto] grid-flow-col items-center',
 						'space-x-2 border-b border-b-gray-600 p-2'
 					)}
 				>
@@ -40,6 +40,27 @@ export const ByPlaylist: React.FC<Props> = ({ filterIds, skipData, countNonPlayl
 					</span>
 					<UriLink object={playlist.owner} className="col-start-2 row-start-2 ellipsis opacity-60" />
 					<span className="row-span-2 justify-self-end">Total skips: {countSkips(playlist)}</span>
+					{playlist.owner?.id === user?.spotify.id && (
+						<button
+							className="row-span-2 justify-self-end opacity-60 hover:opacity-100 text-red-400 hover:text-red-300 text-sm px-2 py-1 border border-current rounded"
+							title={`Remove all tracks with ${minSkips}+ skips from this playlist`}
+							onClick={_ => {
+								const skippedSongs = filterSongs(playlist)
+								const uris = skippedSongs.map(s => idToUri(s.id, 'track'))
+								if (uris.length === 0) return
+								if (window.confirm(`Remove ${uris.length} skipped track(s) from "${playlist.name}"?`)) {
+									dispatch(
+										Actions.deleteTracks(uris, {
+											id: playlist.id as string,
+											snapshot_id: playlist.snapshot_id as string
+										})
+									)
+								}
+							}}
+						>
+							<FontAwesomeIcon icon="trash-alt" size="sm" /> Remove all skipped
+						</button>
+					)}
 				</div>
 				<div className="p-2 grid gap-x-1 grid-cols-[auto,auto,minmax(35%,1fr),repeat(7,auto)] items-baseline">
 					{filterSongs(playlist)

--- a/src/sagas/nowPlaying.ts
+++ b/src/sagas/nowPlaying.ts
@@ -6,6 +6,7 @@ import { spotifyFetch } from './spotifyFetch'
 
 export function* nowPlayingSaga () {
 	yield* takeEvery('PLAYBACK_CLEAR_SKIPS', clearSkips)
+	yield* takeEvery('PLAYBACK_CONTROL', playbackControl)
 	yield* take('TOKEN_AQUIRED')
 	yield* fork(watchPlayback)
 }
@@ -13,6 +14,40 @@ export function* nowPlayingSaga () {
 function* clearSkips (action: Action<'PLAYBACK_CLEAR_SKIPS'>) {
 	const user = yield* select((s: State) => s.user as User) // User will not be null when playback is active
 	yield* call(() => firebaseUpdate(`users/${user.uid}/skips/${action.meta}/${action.payload}/`, 0))
+}
+
+function* playbackControl (action: Action<'PLAYBACK_CONTROL'>) {
+	const playback = yield* select((s: State) => s.playback.nowPlaying)
+	if (!playback) return
+
+	try {
+		switch (action.payload) {
+			case 'play':
+				yield* call(() => spotifyFetch('me/player/play', { method: 'PUT' }))
+				break
+			case 'pause':
+				yield* call(() => spotifyFetch('me/player/pause', { method: 'PUT' }))
+				break
+			case 'next':
+				yield* call(() => spotifyFetch('me/player/next', { method: 'POST' }))
+				break
+			case 'previous':
+				yield* call(() => spotifyFetch('me/player/previous', { method: 'POST' }))
+				break
+			case 'shuffle':
+				yield* call(() => spotifyFetch(`me/player/shuffle?state=${!playback.shuffle_state}`, { method: 'PUT' }))
+				break
+			case 'repeat': {
+				const states = ['off', 'context', 'track'] as const
+				const currentIndex = states.indexOf(playback.repeat_state as typeof states[number])
+				const nextState = states[(currentIndex + 1) % states.length]
+				yield* call(() => spotifyFetch(`me/player/repeat?state=${nextState}`, { method: 'PUT' }))
+				break
+			}
+		}
+	} catch (e) {
+		yield* put(Actions.createNotification({ message: (e as Error).message, type: 'error' }))
+	}
 }
 
 function* watchPlayback () {

--- a/src/utils/Cache.ts
+++ b/src/utils/Cache.ts
@@ -8,6 +8,7 @@ export class PersistentCache<T, K extends string = string> extends Map<K, Readon
 	public id = ''
 	private db: LocalForage
 	private ready: Promise<void>
+	private pendingKeysWrite: Promise<void> = Promise.resolve()
 
 	constructor (id: string) {
 		super()
@@ -25,13 +26,17 @@ export class PersistentCache<T, K extends string = string> extends Map<K, Readon
 		if (key === null) return this
 		super.set(key, value)
 
-		this.db.setItem(key, value).catch(console.warn)
+		this.db.setItem(key, value).catch(err => console.warn(`Cache ${this.id}: failed to write key "${key}"`, err))
 		// As storage APIs does not implement a "getAll", create an entry with all known keys in the cache
-		// Wait for initial load to complete before writing the keys index, otherwise we overwrite it with an incomplete list
-		this.ready.then(() => {
-			const keys = [...this.keys()].filter(k => k !== 'keys')
-			this.db.setItem('keys', keys)
-		})
+		// Chain keys writes sequentially to prevent concurrent writes from clobbering each other
+		this.pendingKeysWrite = this.pendingKeysWrite
+			.then(() => this.ready)
+			.then(() => {
+				const keys = [...this.keys()].filter(k => k !== 'keys')
+				return this.db.setItem('keys', keys)
+			})
+			.then(() => undefined)
+			.catch(err => console.warn(`Cache ${this.id}: failed to write keys index`, err))
 		return this
 	}
 


### PR DESCRIPTION
## Summary
- **Playback Controls**: Wire up NowPlaying bar buttons to Spotify Web API (play/pause/next/prev/shuffle/repeat) — previously all showed "Coming soon!"
- **Skip Surgeon**: Add bulk "Remove all skipped" button per playlist on the Skips page, with confirmation dialog
- **Track Search**: New `/search` page for cross-playlist search by track name, artist, or album with playlist context
- **Library Dashboard**: New `/dashboard` page with library stats (playlist/track counts, duration), duplicate detection, skip rate rankings, and most skipped tracks

## Test plan
- [ ] Verify playback controls work with an active Spotify device (play/pause/next/prev/shuffle/repeat)
- [ ] Verify NowPlaying hides when no device is active
- [ ] Test "Remove all skipped" button on Skips page — confirm dialog appears, tracks are removed
- [ ] Test search with partial matches on track name, artist, and album
- [ ] Verify search handles empty query and no results gracefully
- [ ] Verify dashboard stats load correctly and update as playlists cache
- [ ] Check dashboard skip rate rankings match Skips page data

🤖 Generated with [Claude Code](https://claude.com/claude-code)