### PR TITLE
fix: write Firebase service account JSON to file for CLI auth

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,9 +48,14 @@ jobs:
         env:
           PACKAGE_VERSION: '${{ steps.semver.outputs.VERSION }}'
 
-      - run: yarn firebase deploy --only database
+      - name: Write Firebase service account
         env:
-          GOOGLE_APPLICATION_CREDENTIALS: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_SPOTIFY_ORGANISER }}'
+          SA_KEY: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_SPOTIFY_ORGANISER }}
+        run: |
+          printf '%s' "$SA_KEY" > "$RUNNER_TEMP/firebase-key.json"
+          echo "GOOGLE_APPLICATION_CREDENTIALS=$RUNNER_TEMP/firebase-key.json" >> "$GITHUB_ENV"
+
+      - run: yarn firebase deploy --only database --project spotify-organiser
 
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:


### PR DESCRIPTION
## Summary
- The \`yarn firebase deploy --only database\` step has been broken since the \`ci: deploy db too\` commit — it sets \`GOOGLE_APPLICATION_CREDENTIALS\` to the JSON contents, but the env var expects a *file path*. The hosting action hides this because it auths via its own internal mechanism.
- Write the secret to \`\$RUNNER_TEMP/firebase-key.json\` first, then point the env var at it. Add \`--project\` for explicitness.

## Test plan
- [ ] Merge → master deploy step "Run yarn firebase deploy --only database" succeeds
- [ ] Hosting deploy still succeeds (unchanged path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)