### PR TITLE
fix: deploy hosting before database; allow database step to fail

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,6 +48,13 @@ jobs:
         env:
           PACKAGE_VERSION: '${{ steps.semver.outputs.VERSION }}'
 
+      - uses: FirebaseExtended/action-hosting-deploy@v0
+        with:
+          repoToken: '${{ secrets.GITHUB_TOKEN }}'
+          firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_SPOTIFY_ORGANISER }}'
+          channelId: live
+          projectId: spotify-organiser
+
       - name: Write Firebase service account
         env:
           SA_KEY: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_SPOTIFY_ORGANISER }}
@@ -55,14 +62,9 @@ jobs:
           printf '%s' "$SA_KEY" > "$RUNNER_TEMP/firebase-key.json"
           echo "GOOGLE_APPLICATION_CREDENTIALS=$RUNNER_TEMP/firebase-key.json" >> "$GITHUB_ENV"
 
-      - run: yarn firebase deploy --only database --project spotify-organiser
-
-      - uses: FirebaseExtended/action-hosting-deploy@v0
-        with:
-          repoToken: '${{ secrets.GITHUB_TOKEN }}'
-          firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_SPOTIFY_ORGANISER }}'
-          channelId: live
-          projectId: spotify-organiser
+      - name: Deploy database rules
+        continue-on-error: true
+        run: yarn firebase deploy --only database --project spotify-organiser
 
       - run: yarn release
         if: ${{ steps.semver.outputs.VERSION != '' }}


### PR DESCRIPTION
## Summary
- Hosting deploy is the user-visible release; database rules rarely change.
- Reorder so a missing RTDB role on the service account can't block the hosting deploy.
- Mark the database step \`continue-on-error: true\` so it surfaces failures without blocking the rest of the workflow (release etc.).
- Long-term fix is to grant the SA \`roles/firebasedatabase.admin\` in the GCP console, then this step will go green automatically.

## Test plan
- [ ] Merge → hosting deploys regardless of database step outcome
- [ ] Database step fails red (until SA gets the right role) but doesn't fail the workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)