### PR TITLE
feat: migrate Spotify auth to PKCE + finish yarn-based Firebase deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,19 +48,15 @@ jobs:
         env:
           PACKAGE_VERSION: '${{ steps.semver.outputs.VERSION }}'
 
-      - uses: FirebaseExtended/action-hosting-deploy@v0
-        with:
-          repoToken: '${{ secrets.GITHUB_TOKEN }}'
-          firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_SPOTIFY_ORGANISER }}'
-          channelId: live
-          projectId: spotify-organiser
-
       - name: Write Firebase service account
         env:
           SA_KEY: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_SPOTIFY_ORGANISER }}
         run: |
           printf '%s' "$SA_KEY" > "$RUNNER_TEMP/firebase-key.json"
           echo "GOOGLE_APPLICATION_CREDENTIALS=$RUNNER_TEMP/firebase-key.json" >> "$GITHUB_ENV"
+
+      - name: Deploy hosting
+        run: yarn firebase deploy --only hosting --project spotify-organiser
 
       - name: Deploy database rules
         continue-on-error: true

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -38,8 +38,25 @@ jobs:
         env:
           PACKAGE_VERSION: '-beta'
 
-      - uses: FirebaseExtended/action-hosting-deploy@v0
+      - name: Write Firebase service account
+        env:
+          SA_KEY: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_SPOTIFY_ORGANISER }}
+        run: |
+          printf '%s' "$SA_KEY" > "$RUNNER_TEMP/firebase-key.json"
+          echo "GOOGLE_APPLICATION_CREDENTIALS=$RUNNER_TEMP/firebase-key.json" >> "$GITHUB_ENV"
+
+      - name: Deploy preview channel
+        id: deploy
+        run: |
+          OUT=$(yarn firebase hosting:channel:deploy "pr-${{ github.event.pull_request.number }}" \
+            --project spotify-organiser --expires 7d --json)
+          URL=$(echo "$OUT" | jq -r '.result["spotify-organiser"].url')
+          echo "url=$URL" >> "$GITHUB_OUTPUT"
+
+      - name: Comment preview URL
+        uses: marocchino/sticky-pull-request-comment@v2
         with:
-          repoToken: '${{ secrets.GITHUB_TOKEN }}'
-          firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_SPOTIFY_ORGANISER }}'
-          projectId: spotify-organiser
+          header: firebase-preview
+          message: |
+            Preview deployed: ${{ steps.deploy.outputs.url }}
+            (expires in 7 days)

--- a/src/actions/user.ts
+++ b/src/actions/user.ts
@@ -2,7 +2,9 @@ import { Optional, User } from '~/types'
 import { makeActionCreator } from '~/utils/actionCreator'
 
 export default {
+	codeReceived: makeActionCreator<string, string | null>()('CODE_RECEIVED'),
 	tokenAquired: makeActionCreator<string, string | null>()('TOKEN_AQUIRED'),
+	tokenRefreshed: makeActionCreator<string>()('TOKEN_REFRESHED'),
 	loadUser: makeActionCreator()('LOAD_USER'),
 	userLoaded: makeActionCreator<Optional<User, 'settings'>>()('USER_LOADED'),
 	logout: makeActionCreator()('USER_LOGOUT'),

--- a/src/components/layout/Auth.tsx
+++ b/src/components/layout/Auth.tsx
@@ -2,16 +2,16 @@ import React from 'react'
 import { connect } from 'react-redux'
 import { replace } from 'redux-first-history'
 import { Actions } from '~/actions'
-import { loginLink } from '~/consts'
 import { State } from '~/types'
 import { parseQueryString } from '~/utils/parseQueryString'
+import { loginLink } from '~/utils/spotifyAuth'
 
 const mapStateToProps = (state: State) => ({
 	user: state.user
 })
 
 const dispatchToProps = {
-	tokenAquired: Actions.tokenAquired,
+	codeReceived: Actions.codeReceived,
 	replace
 }
 
@@ -19,9 +19,10 @@ type Props = ReturnType<typeof mapStateToProps> & typeof dispatchToProps
 
 class Login extends React.Component<Props> {
 	componentDidMount () {
-		if (location.href.indexOf('#access_token=') !== -1) {
-			const query = parseQueryString(location.href, true)
-			this.props.tokenAquired(query.access_token, query.state)
+		if (location.search.includes('code=')) {
+			const query = parseQueryString(location.href, false)
+			this.props.codeReceived(query.code, query.state || null)
+			history.replaceState({}, '', location.pathname)
 		}
 	}
 
@@ -29,10 +30,15 @@ class Login extends React.Component<Props> {
 		if (this.props.user) this.props.replace('/')
 	}
 
+	handleLogin = async (e: React.MouseEvent) => {
+		e.preventDefault()
+		window.location.href = await loginLink()
+	}
+
 	render () {
 		return (
 			<div className="auth">
-				<a className="button primary" href={loginLink()}>
+				<a className="button primary" href="#" onClick={this.handleLogin}>
 					Log in to Spotify
 				</a>
 			</div>

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -1,24 +1,3 @@
-import { Scopes } from './types'
-import { urlEscape } from './utils'
-
 export const __DEV__ = process.env.NODE_ENV !== 'production'
 export const REDIRECT_URI = __DEV__ ? 'http://localhost:1337' : 'https://spotify-organiser.web.app'
-
-const id = '4a3ae815c2a0443c824541a7aa94cfcc'
-const scopes = [
-	Scopes.PLAYLIST_READ_PRIVATE,
-	Scopes.PLAYLIST_MODIFY_PRIVATE,
-	Scopes.PLAYLIST_MODIFY_PUBLIC,
-	Scopes.USER_LIBRARY_READ,
-	Scopes.USER_LIBRARY_MODIFY,
-	Scopes.STREAMING,
-	Scopes.USER_READ_PLAYBACK_POSITION,
-	Scopes.USER_READ_CURRENTLY_PLAYING,
-	Scopes.USER_READ_PLAYBACK_STATE,
-	Scopes.USER_MODIFY_PLAYBACK_STATE
-]
-
-export const loginLink = () =>
-	urlEscape`https://accounts.spotify.com/authorize?client_id=${id}&response_type=token&redirect_uri=${REDIRECT_URI}&scope=${scopes.join(
-		' '
-	)}&state=${window.location.pathname}`
+export const CLIENT_ID = '4a3ae815c2a0443c824541a7aa94cfcc'

--- a/src/reducers/user.ts
+++ b/src/reducers/user.ts
@@ -22,6 +22,9 @@ export default function user (state: User | null = null, action: Action): User |
 			}
 		case 'USER_LOGOUT':
 			return null
+		case 'TOKEN_REFRESHED':
+			if (!state) return state
+			return { ...state, spotifyToken: action.payload }
 		case 'USER_SETTINGS_UPDATE':
 			if (!state) return state
 			return {

--- a/src/sagas/login.ts
+++ b/src/sagas/login.ts
@@ -2,12 +2,28 @@ import { signInAnonymously } from 'firebase/auth'
 import { replace } from 'redux-first-history'
 import { call, put, takeLatest } from 'typed-redux-saga'
 import { Action, Actions } from '~/actions'
+import { clearTokens, exchangeCodeForToken, refreshAccessToken, storeTokens } from '~/utils/spotifyAuth'
 import { auth } from '../utils/firebase'
 import { spotifyFetch } from './spotifyFetch'
 
 export function* loginSaga () {
+	yield* takeLatest(Actions.codeReceived.type, exchangeCode)
 	yield* takeLatest(Actions.tokenAquired.type, getUserDetails)
 	yield* takeLatest('LOAD_USER', loadUser)
+	yield* takeLatest(Actions.logout.type, onLogout)
+}
+
+function* exchangeCode (action: Action<typeof Actions.codeReceived.type>) {
+	try {
+		const tokens = yield* call(exchangeCodeForToken, action.payload)
+		storeTokens(tokens)
+		yield* put(Actions.tokenAquired(tokens.access_token, action.meta))
+	} catch (e) {
+		console.error(`${exchangeCode.name}:`, e)
+		yield* put(
+			Actions.createNotification({ message: `Login failed: ${(e as Error).message}`, type: 'warning' })
+		)
+	}
 }
 
 function* getUserDetails (action: Action<typeof Actions.tokenAquired.type>) {
@@ -30,7 +46,6 @@ function* getUserDetails (action: Action<typeof Actions.tokenAquired.type>) {
 				})
 			)
 		}
-		localStorage.setItem('token', token)
 		yield* put(Actions.fetchPlaylists())
 		const redirect = action.meta
 		if (redirect && redirect !== location.pathname) {
@@ -47,8 +62,24 @@ function* getUserDetails (action: Action<typeof Actions.tokenAquired.type>) {
 
 function* loadUser (_: Action<typeof Actions.loadUser.type>) {
 	const token = localStorage.getItem('token')
+	const refreshToken = localStorage.getItem('refresh_token')
+
 	if (token) {
 		yield* call(signInAnonymously, auth)
 		yield* put(Actions.tokenAquired(token, null))
+	} else if (refreshToken) {
+		try {
+			const tokens = yield* call(refreshAccessToken, refreshToken)
+			storeTokens(tokens)
+			yield* call(signInAnonymously, auth)
+			yield* put(Actions.tokenAquired(tokens.access_token, null))
+		} catch (e) {
+			console.warn('Failed to refresh token on load:', e)
+			clearTokens()
+		}
 	}
+}
+
+function* onLogout (_: Action<typeof Actions.logout.type>) {
+	yield* call(clearTokens)
 }

--- a/src/sagas/spotifyFetch.ts
+++ b/src/sagas/spotifyFetch.ts
@@ -1,9 +1,9 @@
 import { SagaIterator } from 'redux-saga'
 import { call, put, select } from 'typed-redux-saga'
 import { Actions } from '~/actions'
-import { loginLink } from '~/consts'
 import { State } from '~/types'
 import { sleep } from '~/utils'
+import { refreshAccessToken, storeTokens } from '~/utils/spotifyAuth'
 
 // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-constraint
 export function* spotifyFetch<T extends unknown> (
@@ -33,10 +33,22 @@ export function* spotifyFetch<T extends unknown> (
 		case 204:
 			return null
 
-		case 401:
+		case 401: {
+			const refreshToken = localStorage.getItem('refresh_token')
+			if (refreshToken) {
+				try {
+					const tokens = yield* call(refreshAccessToken, refreshToken)
+					storeTokens(tokens)
+					yield* put(Actions.tokenRefreshed(tokens.access_token))
+					const next = yield* call(spotifyFetch, url, options, tokens.access_token)
+					return next as T | null
+				} catch (e) {
+					console.error('Token refresh failed:', e)
+				}
+			}
 			yield* put(Actions.logout())
-			setTimeout(() => window.open(loginLink(), '_self'), 5000)
 			break
+		}
 		case 429: {
 			const waitTime = Number.parseInt(response.headers.get('Retry-After') || '10', 10)
 			yield* put(Actions.startTimer(waitTime))

--- a/src/utils/SpotifyPlayer.ts
+++ b/src/utils/SpotifyPlayer.ts
@@ -1,4 +1,20 @@
+import { refreshAccessToken, storeTokens } from './spotifyAuth'
+
 export let player: Spotify.Player | null = null
+
+async function getFreshToken (): Promise<string | null> {
+	const refreshToken = localStorage.getItem('refresh_token')
+	if (refreshToken) {
+		try {
+			const tokens = await refreshAccessToken(refreshToken)
+			storeTokens(tokens)
+			return tokens.access_token
+		} catch (e) {
+			console.error('Failed to refresh token for player:', e)
+		}
+	}
+	return localStorage.getItem('token')
+}
 
 export async function initializePlayer (): Promise<Spotify.Player> {
 	if (player !== null) return player
@@ -9,17 +25,18 @@ export async function initializePlayer (): Promise<Spotify.Player> {
 
 	return new Promise((resolve, reject) => {
 		window.onSpotifyWebPlaybackSDKReady = () => {
-			const token = localStorage.getItem('token')
-			if (token) {
-				console.info('Initializing Spotify Playback SDK')
-			} else {
+			if (!localStorage.getItem('token')) {
 				reject(new Error('Cannot initialize Spotify Playback SDK, missing auth token'))
 				return
 			}
+			console.info('Initializing Spotify Playback SDK')
 
 			player = new Spotify.Player({
 				name: 'Web Playback SDK Quick Start Player',
-				getOAuthToken: cb => cb(token),
+				getOAuthToken: async cb => {
+					const token = await getFreshToken()
+					if (token) cb(token)
+				},
 				volume: 0.5
 			})
 

--- a/src/utils/spotifyAuth.ts
+++ b/src/utils/spotifyAuth.ts
@@ -1,0 +1,110 @@
+import { CLIENT_ID, REDIRECT_URI } from '~/consts'
+import { Scopes } from '~/types'
+
+const TOKEN_ENDPOINT = 'https://accounts.spotify.com/api/token'
+const AUTHORIZE_ENDPOINT = 'https://accounts.spotify.com/authorize'
+const VERIFIER_KEY = 'spotify_pkce_verifier'
+
+const scopes = [
+	Scopes.PLAYLIST_READ_PRIVATE,
+	Scopes.PLAYLIST_MODIFY_PRIVATE,
+	Scopes.PLAYLIST_MODIFY_PUBLIC,
+	Scopes.USER_LIBRARY_READ,
+	Scopes.USER_LIBRARY_MODIFY,
+	Scopes.STREAMING,
+	Scopes.USER_READ_PLAYBACK_POSITION,
+	Scopes.USER_READ_CURRENTLY_PLAYING,
+	Scopes.USER_READ_PLAYBACK_STATE,
+	Scopes.USER_MODIFY_PLAYBACK_STATE
+]
+
+export interface TokenResponse {
+	access_token: string
+	refresh_token: string
+	expires_in: number
+	token_type: string
+	scope: string
+}
+
+function base64urlEncode (buffer: ArrayBuffer): string {
+	return btoa(String.fromCharCode(...new Uint8Array(buffer)))
+		.replace(/\+/g, '-')
+		.replace(/\//g, '_')
+		.replace(/=+$/, '')
+}
+
+function randomVerifier (): string {
+	const bytes = new Uint8Array(64)
+	crypto.getRandomValues(bytes)
+	return base64urlEncode(bytes.buffer)
+}
+
+async function sha256 (input: string): Promise<ArrayBuffer> {
+	return crypto.subtle.digest('SHA-256', new TextEncoder().encode(input))
+}
+
+export async function loginLink (): Promise<string> {
+	const verifier = randomVerifier()
+	sessionStorage.setItem(VERIFIER_KEY, verifier)
+	const challenge = base64urlEncode(await sha256(verifier))
+
+	const params = new URLSearchParams({
+		client_id: CLIENT_ID,
+		response_type: 'code',
+		redirect_uri: REDIRECT_URI,
+		scope: scopes.join(' '),
+		code_challenge_method: 'S256',
+		code_challenge: challenge,
+		state: window.location.pathname
+	})
+	return `${AUTHORIZE_ENDPOINT}?${params}`
+}
+
+export async function exchangeCodeForToken (code: string): Promise<TokenResponse> {
+	const verifier = sessionStorage.getItem(VERIFIER_KEY)
+	if (!verifier) throw new Error('Missing PKCE verifier — restart login')
+
+	const body = new URLSearchParams({
+		grant_type: 'authorization_code',
+		code,
+		redirect_uri: REDIRECT_URI,
+		client_id: CLIENT_ID,
+		code_verifier: verifier
+	})
+
+	const res = await fetch(TOKEN_ENDPOINT, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+		body
+	})
+	if (!res.ok) throw new Error(`Token exchange failed: ${res.status} ${await res.text()}`)
+
+	sessionStorage.removeItem(VERIFIER_KEY)
+	return res.json()
+}
+
+export async function refreshAccessToken (refreshToken: string): Promise<TokenResponse> {
+	const body = new URLSearchParams({
+		grant_type: 'refresh_token',
+		refresh_token: refreshToken,
+		client_id: CLIENT_ID
+	})
+
+	const res = await fetch(TOKEN_ENDPOINT, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+		body
+	})
+	if (!res.ok) throw new Error(`Token refresh failed: ${res.status}`)
+	return res.json()
+}
+
+export function storeTokens (tokens: TokenResponse) {
+	localStorage.setItem('token', tokens.access_token)
+	localStorage.setItem('refresh_token', tokens.refresh_token)
+}
+
+export function clearTokens () {
+	localStorage.removeItem('token')
+	localStorage.removeItem('refresh_token')
+}


### PR DESCRIPTION
## Summary

Two related changes bundled together on this branch:

### Spotify auth — migrate to Authorization Code with PKCE
Spotify deprecated the Implicit Grant flow (`response_type=token`), so the existing login was about to break. Migrating to Authorization Code with PKCE — the supported flow for SPAs — and using the returned refresh token to silently refresh expired access tokens.

- New `src/utils/spotifyAuth.ts` encapsulates PKCE challenge generation, the `/authorize` URL builder, code exchange, and refresh-token grant.
- `Auth.tsx` now handles the `?code=` callback (was `#access_token=`) and generates the verifier on login click.
- 401s in `spotifyFetch` attempt a silent refresh before logging out — replaces the previous "logout + redirect to login after 5s" behavior.
- Cold-start (`loadUser`) falls back to refresh-token if no access token is in `localStorage`.
- `SpotifyPlayer.getOAuthToken` callback now refreshes on demand so playback survives past the 1-hour access-token expiry.

### CI — finish the yarn-based Firebase deploy migration
Removes the leftover `FirebaseExtended/action-hosting-deploy` step from `deploy.yml` (replaced with `yarn firebase deploy --only hosting`) and rewrites `preview.yml` to deploy a per-PR preview channel with a sticky comment for the URL. Completes the migration started in #74/#75.

## Test plan

- [ ] Verify Spotify Redirect URI whitelist in the Spotify dashboard still includes `https://spotify-organiser.web.app` and `http://localhost:1337`
- [ ] Local: `yarn dev`, click "Log in to Spotify" → expect `accounts.spotify.com/authorize?...&response_type=code&code_challenge=...`
- [ ] After approving, return to app with `?code=...` → token exchange succeeds, user loads, URL cleans up
- [ ] Leave app running >1h, confirm `getOAuthToken`/refresh keeps playback working without re-login
- [ ] Force a 401 (revoke token in another tab) → confirm silent refresh on next API call
- [ ] CI: open this PR → `preview.yml` deploys a `pr-<N>` channel and posts a sticky comment with the URL
- [ ] CI: merge to master → `deploy.yml` deploys hosting via yarn CLI (not the FirebaseExtended action) and database rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)