### PR TITLE
fix: use $GITHUB_OUTPUT instead of deprecated ::set-output

### DIFF
--- a/scripts/semver.sh
+++ b/scripts/semver.sh
@@ -9,7 +9,7 @@ VERSION=$(cat .version)
 
 if [ -s .version ]; then
 	echo "Next version: $VERSION"
-	echo "::set-output name=VERSION::$VERSION"
+	echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
 else
 	echo "No new version. Canceling deploy."
 fi


### PR DESCRIPTION
## Summary
- Replaces `echo \"::set-output name=VERSION::\$VERSION\"` in `scripts/semver.sh` with the `\$GITHUB_OUTPUT` file syntax. GitHub disabled the legacy workflow command in 2023, so `steps.semver.outputs.VERSION` has been silently empty on every prod deploy.
- This is why prod displays `Spotify Organiser v‑local` — `webpack.config.ts` falls back to `'‑local'` when `PACKAGE_VERSION` is missing.
- Same bug also meant the `yarn release` step at the end of the workflow was being skipped (its `if:` condition checks the same empty output), so no git tags / GitHub releases have been created.

## Test plan
- [ ] Merge and confirm next deploy's `Get version number` step logs a non-empty `VERSION` in `$GITHUB_OUTPUT`
- [ ] Prod status bar shows `vX.Y.Z` instead of `v‑local`
- [ ] A semantic-release tag + GitHub release appears for the deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)