### PR TITLE
fix: unblock login stuck on Firebase auth IndexedDB deadlock

### DIFF
--- a/src/consts.ts
+++ b/src/consts.ts
@@ -1,3 +1,3 @@
 export const __DEV__ = process.env.NODE_ENV !== 'production'
-export const REDIRECT_URI = __DEV__ ? 'http://localhost:1337' : 'https://spotify-organiser.web.app'
+export const REDIRECT_URI = __DEV__ ? 'http://127.0.0.1:1337' : 'https://spotify-organiser.web.app'
 export const CLIENT_ID = '4a3ae815c2a0443c824541a7aa94cfcc'

--- a/src/utils/firebase.ts
+++ b/src/utils/firebase.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-restricted-imports */
 import { FirebaseOptions, initializeApp } from 'firebase/app'
-import { getAuth } from 'firebase/auth'
+import { inMemoryPersistence, initializeAuth } from 'firebase/auth'
 import { get, getDatabase, onValue, ref, update } from 'firebase/database'
 import { FirebaseGet, FirebaseUpdates, FirebaseUrls } from '~/types'
 
@@ -20,7 +20,10 @@ const firebaseConfig: FirebaseOptions = {
 
 const app = initializeApp(firebaseConfig)
 const db = getDatabase(app)
-export const auth = getAuth(app)
+// IndexedDB-backed auth persistence can deadlock when the firebaseLocalStorageDb
+// is held open elsewhere — signInAnonymously then never fires its network
+// request. We re-auth anonymously on every load anyway, so in-memory works.
+export const auth = initializeAuth(app, { persistence: inMemoryPersistence })
 
 export function firebaseWatch<T extends FirebaseUrls> (url: T, onUpdate: (value: FirebaseGet<T>) => void) {
 	const key = url.endsWith('/') ? url.slice(0, -1) : url


### PR DESCRIPTION
## Summary
- **Prod**: signInAnonymously deadlocks on \`firebaseLocalStorageDb\` (verified: opening or deleting the IDB hangs forever in the live tab). The \`loadUser\` saga stalls, \`userLoaded\` never fires, and the UI shows the login page even though the Spotify token in \`localStorage\` is still valid — that's why parts that read the token directly (player, /me) keep working. Switching Firebase Auth to \`inMemoryPersistence\` via \`initializeAuth\` skips IndexedDB entirely. We re-auth anonymously on every cold start, so persistence wasn't buying us anything.
- **Dev**: Spotify deprecated \`http://localhost\` redirect URIs — \`/authorize\` now returns "redirect_uri: Insecure". Switched the dev redirect to \`http://127.0.0.1:1337\`.

## Action required
Add \`http://127.0.0.1:1337\` to the Redirect URIs in the Spotify app dashboard. The old \`http://localhost:1337\` entries are now dead.

## Test plan
- [ ] Production: load https://spotify-organiser.web.app with valid \`token\` in localStorage → app shows main UI (not login page)
- [ ] Production: fresh login round-trip works end to end
- [ ] Dev: \`yarn dev\`, visit http://127.0.0.1:1337, click "Log in to Spotify" → Spotify accepts the redirect (after dashboard update)
- [ ] Firebase Realtime DB reads/writes (skips/plays) still work — auth still gets a uid, just stored in memory

🤖 Generated with [Claude Code](https://claude.com/claude-code)