### PR TITLE
fix(pwa): resolve Workbox precache conflict on service worker init

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -39,7 +39,6 @@ export default defineConfig({
 		VitePWA({
 			registerType: 'prompt',
 			injectRegister: false,
-			includeAssets: ['static/favicon.svg', 'static/favicon.png', 'static/app.svg'],
 			manifestFilename: 'static/app.webmanifest',
 			manifest: {
 				name: 'Spotify Organiser',
@@ -59,6 +58,7 @@ export default defineConfig({
 			},
 			workbox: {
 				globPatterns: ['**/*.{js,css,html,svg,png,webmanifest}'],
+				globIgnores: ['**/static/app.svg', '**/static/app.webmanifest'],
 				navigateFallback: '/index.html',
 				navigateFallbackDenylist: [/^\/static\/app\.webmanifest$/],
 				cleanupOutdatedCaches: true,


### PR DESCRIPTION
## Summary

Service worker registration was failing at runtime with:

```
add-to-cache-list-conflicting-entries :: [{"firstEntry":".../static/app.svg","secondEntry":".../static/app.svg?__WB_REVISION__=845412bab..."}]
```

VitePWA was adding `static/app.svg` and `static/app.webmanifest` to the Workbox precache **twice** — once via `globPatterns` (with `revision: null`) and once via the plugin auto-including the manifest itself and the icons referenced from it (with a content-hash revision). Workbox's `PrecacheController` rejects two entries pointing at the same URL with different revisions.

## Fix

- Drop the `includeAssets` list — those files live in `public/` and are copied to `dist/` automatically, so `globPatterns` already covers them.
- Add `globIgnores` for `static/app.svg` and `static/app.webmanifest` so the glob doesn't double-precache the manifest file and the icon the plugin already includes via the manifest.

After the fix, the precache list contains 8 unique entries:

```
index.html                       (hash revision)
static/vendor-*.js               (null — hash in filename)
static/index-*.js                (null — hash in filename)
static/index-*.css               (null — hash in filename)
static/favicon.svg               (null)
static/favicon.png               (null)
static/app.svg                   (hash revision, from manifest icon)
static/app.webmanifest           (hash revision, from manifest gen)
```

## Test plan

- [x] `yarn build` succeeds; `dist/sw.js` contains no duplicate URL entries
- [ ] Load the deployed app, confirm SW registers without the `add-to-cache-list-conflicting-entries` error in console
- [ ] Trigger an update — confirm the update prompt still fires and `skipWaiting` flow works
- [ ] Offline reload: `static/app.svg`, manifest icons, and `app.webmanifest` are still served from cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)