### PR TITLE
feat: show skip count column in playlist track view

### DIFF
--- a/src/components/Tracks.tsx
+++ b/src/components/Tracks.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from 'react'
 import { Playlist, Track } from '~/types'
-import { Duration, useAppSelector } from '~/utils'
+import { Duration, idToUri, useAppSelector, useFirebase } from '~/utils'
 import { ArtistLinks, UriLink } from './UriLink'
 
 type Props = {
@@ -9,8 +9,13 @@ type Props = {
 }
 const Tracks: React.FC<Props> = ({ tracks, currentPlaylistId }) => {
 	const playlists = useAppSelector(s => s.playlists)
+	const user = useAppSelector(s => s.user)
+	const playlistUri = currentPlaylistId ? idToUri(currentPlaylistId, 'playlist') : null
+	// Per-playlist skip counts, keyed by track id. Mirrors how Skips pages load skip data.
+	const skipEntries = useFirebase(`users/${user?.uid}/skips/${playlistUri}/`) || {}
 	const contributors = new Set(tracks.map(t => t.meta.added_by.id))
 	const plays = tracks.reduce((a, t) => a + (t.meta.plays || 0), 0)
+	const skips = tracks.reduce((a, t) => a + (skipEntries[t.id] || 0), 0)
 
 	const otherPlaylistsByTrack = useMemo(() => {
 		const map: Record<Track['id'], Playlist[]> = {}
@@ -33,6 +38,7 @@ const Tracks: React.FC<Props> = ({ tracks, currentPlaylistId }) => {
 					<th>Duration</th>
 					<th title="Number of other loaded playlists this track appears in">In playlists</th>
 					<th title={plays > 0 ? undefined : 'Plays are tracked only while "Watch skips" is enabled in settings'}>Plays</th>
+					<th title={skips > 0 ? undefined : 'Skips are tracked only while "Watch skips" is enabled in settings'}>Skips</th>
 				</tr>
 			</thead>
 			<tbody>
@@ -60,6 +66,7 @@ const Tracks: React.FC<Props> = ({ tracks, currentPlaylistId }) => {
 							<td>{new Duration(track.duration_ms).toMinutesString()}</td>
 							<td title={others.map(pl => pl.name).join('\n')}>{others.length}</td>
 							<td>{track.meta.plays ?? 0}</td>
+							<td>{skipEntries[track.id] ?? 0}</td>
 						</tr>
 					)
 				})}


### PR DESCRIPTION
## Summary

- Adds a **Skips** column to the playlist track table, next to the existing **Plays** column. Closes #66.
- Reads per-playlist skip data via the existing `useFirebase` hook in `Tracks.tsx` — same mechanism the Skips page uses, no new saga or fetcher introduced.
- Empty / never-tracked tracks render `0` (matching the existing Plays column behaviour). The header tooltip explains that skips only get tracked while *Watch skips* is enabled in settings.

## Design decisions

- **Show `0` rather than a dash / hide** for tracks with no recorded skips. This matches how the existing Plays column renders, keeps the table grid clean, and lets the header tooltip carry the "you need Watch skips on" hint (same pattern as the Plays column).
- **No sortable headers**: `Tracks.tsx` doesn't currently support click-to-sort on any column; out of scope per task constraints.
- **No new Redux slice**: `useFirebase("users/{uid}/skips/{playlistUri}/")` returns just this playlist's skips, scoped tighter than the Skips page's full-tree fetch.
- **Header tooltip wording** mirrors the Plays column tooltip ("tracked only while 'Watch skips' is enabled").

## Test plan

- [x] `yarn lint`
- [x] `yarn stylelint`
- [x] `yarn test`
- [x] `yarn prod` (production build succeeds)
- [ ] Smoke-check the playlist track view on the PR preview — verify the new column renders and shows real skip counts for tracks with recorded skips
- [ ] Verify rows for tracks with no skip data show `0`