### PR TITLE
feat: bulk make public/private actions for selected playlists

### DIFF
--- a/src/actions/playlists.ts
+++ b/src/actions/playlists.ts
@@ -1,4 +1,3 @@
-
 import { Playlist, Sort, Track } from '~/types'
 import { CompareType } from '~/utils'
 import { makeActionCreator, makeMetaActionCreator } from '~/utils/actionCreator'
@@ -26,6 +25,9 @@ export default {
 	deduplicatePlaylists: makeActionCreator<{ source: Playlist[]; target: Playlist | null }, CompareType>()(
 		'DEDUPLICATE_PLAYLISTS'
 	),
+
+	setPlaylistsVisibility: makeActionCreator<boolean, Array<Playlist['id']>>()('PLAYLISTS_SET_VISIBILITY'),
+	playlistVisibilityUpdated: makeActionCreator<boolean, Playlist['id']>()('PLAYLISTS_SET_VISIBILITY_SUCCESS'),
 
 	deleteTracks: makeActionCreator<Array<Track['uri']>, PlaylistMeta>()('PLAYLIST_DELETE_TRACKS')
 }

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -29,7 +29,8 @@ const dispatchToProps = {
 	select: Actions.selectPlaylist,
 	changeSortMode: Actions.updatePlaylistsSort,
 	updateFilterText: Actions.updateFilterText,
-	deduplicate: Actions.deduplicatePlaylists
+	deduplicate: Actions.deduplicatePlaylists,
+	setVisibility: Actions.setPlaylistsVisibility
 }
 
 const PlaylistsManager: React.FC = () => {
@@ -37,9 +38,20 @@ const PlaylistsManager: React.FC = () => {
 	const [compareType, setCompareType] = useState<CompareType | null>(null)
 	const [secondPlaylist, setSecondPlaylist] = useState<Playlist | null>(null)
 	const { filters, user, playlists: allPlaylists } = useSelector(mapStateToProps)
-	const { select, selectAll, changeSortMode, updateFilterText, deduplicate } = useMapDispatch(dispatchToProps)
+	const { select, selectAll, changeSortMode, updateFilterText, deduplicate, setVisibility } =
+		useMapDispatch(dispatchToProps)
 	const playlists = applyPlaylistsFilters(allPlaylists, filters, user)
 	const selectedPlaylists = playlists.filter(p => p.selected)
+	const ownedSelected = user ? selectedPlaylists.filter(pl => pl.owner.id === user.spotify.id) : []
+	const skippedCount = selectedPlaylists.length - ownedSelected.length
+	const visibilityDisabled = ownedSelected.length === 0
+	const visibilityTitle = visibilityDisabled
+		? selectedPlaylists.length === 0
+			? 'Select at least one playlist you own'
+			: 'Spotify only allows the owner to change a playlist’s visibility'
+		: skippedCount > 0
+			? `${skippedCount} non-owned playlist${skippedCount === 1 ? '' : 's'} will be skipped`
+			: ''
 
 	const handleInputChange = (event: React.FormEvent<HTMLInputElement>) => {
 		const target = event.currentTarget
@@ -94,14 +106,42 @@ const PlaylistsManager: React.FC = () => {
 							</Button>
 						</>
 					) : (
-						<Button
-							primary
-							disabled={compareType !== null && selectedPlaylists.length === 0}
-							onClick={_ => setMode(OperationMode.Duplicates)}
-							title={error || ''}
-						>
-							Remove duplicates
-						</Button>
+						<>
+							<Button
+								primary
+								disabled={compareType !== null && selectedPlaylists.length === 0}
+								onClick={_ => setMode(OperationMode.Duplicates)}
+								title={error || ''}
+							>
+								Remove duplicates
+							</Button>
+							<Button
+								icon="lock-open"
+								disabled={visibilityDisabled}
+								title={visibilityTitle}
+								onClick={_ =>
+									setVisibility(
+										true,
+										ownedSelected.map(pl => pl.id)
+									)
+								}
+							>
+								Make public
+							</Button>
+							<Button
+								icon="lock"
+								disabled={visibilityDisabled}
+								title={visibilityTitle}
+								onClick={_ =>
+									setVisibility(
+										false,
+										ownedSelected.map(pl => pl.id)
+									)
+								}
+							>
+								Make private
+							</Button>
+						</>
 					)}
 					<span className="filler" />
 					<ul className="stats right-menu flex gap-3 max-w-sm">

--- a/src/reducers/playlists.ts
+++ b/src/reducers/playlists.ts
@@ -18,6 +18,8 @@ function playlist (state: Playlist, action: MetaAction): Playlist {
 			return action.payload
 		case 'PLAYLISTS_SELECT':
 			return { ...state, selected: action.payload }
+		case 'PLAYLISTS_SET_VISIBILITY_SUCCESS':
+			return { ...state, public: action.payload }
 		default:
 			return state
 	}
@@ -34,6 +36,7 @@ export default function playlists (state: Playlist[] = [], action: Action): Play
 		case 'PLAYLISTS_SELECT':
 		case 'FETCH_TRACKS_SUCCESS':
 		case 'FETCH_TRACKS_PROGRESS':
+		case 'PLAYLISTS_SET_VISIBILITY_SUCCESS':
 			return state.map(p => playlist(p, action))
 		case 'PLAYLISTS_SELECT_ALL':
 			return state.map(p => ({ ...p, selected: action.payload }))

--- a/src/sagas/playlists.ts
+++ b/src/sagas/playlists.ts
@@ -9,6 +9,7 @@ export function* playlistsSaga () {
 	yield* takeLatest('FETCH_PLAYLISTS', getPlaylists)
 	yield* takeLatest('DEDUPLICATE_PLAYLISTS', deduplicatePlaylists)
 	yield* takeEvery('PLAYLIST_DELETE_TRACKS', deleteTracks)
+	yield* takeEvery('PLAYLISTS_SET_VISIBILITY', setPlaylistsVisibility)
 }
 
 function* getPlaylists () {
@@ -110,5 +111,62 @@ function* deduplicatePlaylists (action: Action<'DEDUPLICATE_PLAYLISTS'>) {
 		yield* put(Actions.fetchPlaylists())
 	} catch (err) {
 		yield* put(Actions.createNotification({ message: (err as Error).message, type: 'error' }))
+	}
+}
+
+function* setPlaylistsVisibility (action: Action<'PLAYLISTS_SET_VISIBILITY'>) {
+	const { payload: isPublic, meta: ids } = action
+	const user = yield* select((state: State) => state.user)
+	if (!user) return
+
+	// Spotify only allows the playlist owner to change visibility (collaborative editors can't).
+	const targets: Playlist[] = yield* select((state: State) =>
+		state.playlists.filter(pl => ids.includes(pl.id) && pl.owner.id === user.spotify.id)
+	)
+	const skipped = ids.length - targets.length
+	if (targets.length === 0) {
+		yield* put(
+			Actions.createNotification({
+				type: 'warning',
+				message: 'No editable playlists selected — Spotify only lets you modify playlists you own.'
+			})
+		)
+		return
+	}
+
+	const label = isPublic ? 'public' : 'private'
+	let updated = 0
+	const failed: string[] = []
+	for (const pl of targets) {
+		if (pl.public === isPublic) {
+			updated += 1
+			continue
+		}
+		try {
+			yield* call(spotifyFetch, `playlists/${pl.id}`, {
+				method: 'PUT',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ public: isPublic })
+			})
+			yield* put(Actions.playlistVisibilityUpdated(isPublic, pl.id))
+			updated += 1
+		} catch (e) {
+			failed.push(pl.name)
+			yield* put(
+				Actions.createNotification({
+					type: 'error',
+					message: `Failed to make "${pl.name}" ${label}: ${(e as Error).message}`
+				})
+			)
+		}
+	}
+
+	if (failed.length === 0) {
+		const skippedSuffix = skipped > 0 ? ` (${skipped} not owned by you skipped)` : ''
+		yield* put(
+			Actions.createNotification({
+				message: `${updated} playlist${updated === 1 ? '' : 's'} set to ${label}${skippedSuffix}`
+			})
+		)
 	}
 }


### PR DESCRIPTION
Closes #11.

## Summary

Adds two toolbar buttons in the Playlists view ("Make public" / "Make private") that flip the `public` flag on every selected playlist by calling `PUT /v1/playlists/{id}` with `{ public: boolean }`.

## Files changed

- `src/actions/playlists.ts` — new `setPlaylistsVisibility(payload: boolean, meta: string[])` action that triggers the saga, plus a per-playlist success action `playlistVisibilityUpdated(payload: boolean, meta: string)` for keeping Redux state in sync.
- `src/reducers/playlists.ts` — handle `PLAYLISTS_SET_VISIBILITY_SUCCESS` by updating each affected playlist's `public` field in place.
- `src/sagas/playlists.ts` — `setPlaylistsVisibility` saga: filters to owned playlists, skips any already in the target state, fires sequential `PUT` requests via `spotifyFetch`, dispatches success per-playlist and a single summary notification (or per-failure error notifications).
- `src/pages/Home.tsx` — two new `Button`s next to "Remove duplicates" with `lock-open` / `lock` icons. Disabled when no owned playlist is selected; tooltip indicates if some non-owned selections will be skipped.

## Design decisions

- **Ownership**: Spotify only lets the playlist owner change the `public` field (collaborative editors cannot). The UI buttons are enabled if at least one *owned* playlist is selected; non-owned selections are silently skipped at saga time and counted in the success notification. The button tooltip surfaces a "N non-owned playlist(s) will be skipped" hint when the selection is mixed.
- **Toolbar placement**: Existing toolbar in `src/pages/Home.tsx` next to the "Remove duplicates" button — same `row` container, same `Button` component. No new layout primitives.
- **Confirmation UX**: No modal. Flipping public/private is reversible and low-risk; matches the existing pattern where only destructive operations (`deduplicate`) use `window.confirm`. Result is surfaced via the existing notification system.
- **Scopes**: `playlist-modify-public` and `playlist-modify-private` are already requested in `src/utils/spotifyAuth.ts`, so no auth changes are needed.
- **State management**: Stuck to `legacy_createStore` + `redux-saga` + `makeActionCreator` patterns. No new tooling.

## Verification

- `yarn lint` — passes
- `yarn stylelint` — passes
- `yarn test` — 30/30 pass
- `yarn prod` — clean build (no new warnings vs. master)
- Pre-push hook (lint + stylelint) — passed when pushing the branch

## Open question

There is no per-playlist `public` indicator in the playlist list yet. Could be a small follow-up (column or icon overlay) but felt out of scope for this issue. Happy to add it in a follow-up if you'd like.