### PR TITLE
fix(auth): unblock Spotify login, stabilize Firebase identity for play history

### DIFF
--- a/database.rules.json
+++ b/database.rules.json
@@ -1,9 +1,16 @@
 {
 	"rules": {
+		"uidMap": {
+			"$firebaseUid": {
+				".read": "$firebaseUid === auth.uid",
+				".write": "$firebaseUid === auth.uid",
+				".validate": "newData.isString() && newData.val().length > 0 && newData.val().length < 256"
+			}
+		},
 		"users": {
-			"$uid": {
-				".read": "$uid === auth.uid",
-				".write": "$uid === auth.uid"
+			"$key": {
+				".read": "auth != null && ($key === auth.uid || root.child('uidMap').child(auth.uid).val() === $key)",
+				".write": "auth != null && ($key === auth.uid || root.child('uidMap').child(auth.uid).val() === $key)"
 			}
 		}
 	}

--- a/scripts/consolidate-uids.ts
+++ b/scripts/consolidate-uids.ts
@@ -1,0 +1,84 @@
+/* eslint-disable no-console */
+
+// Offline migration to recover plays/skips from past Firebase anonymous uids.
+//
+// Background: before commit 531be69 we used Firebase Auth's IndexedDB
+// persistence, which deadlocked. The deadlock fix switched to
+// inMemoryPersistence, which mints a NEW anonymous uid on every reload —
+// scattering plays/skips across many `users/<anonUid>/...` buckets that the
+// new persistence/identity model can no longer reach from the client.
+//
+// This script takes an export of the `/users` subtree from the Firebase
+// console, merges every anon-uid bucket's plays+skips counters into a single
+// target bucket (your Spotify user id), and writes back a JSON file you can
+// re-import into Firebase. Plays and skips for the same (playlistUri, songId)
+// are summed.
+//
+// Usage:
+//   1. In the Firebase console (Realtime Database → /users node), click ⋮ →
+//      "Export JSON". Save as scripts/users-export.json.
+//   2. yarn ts-node scripts/consolidate-uids.ts <yourSpotifyUserId>
+//   3. Upload scripts/users-merged.json back to /users via "Import JSON".
+//
+// The script does NOT touch the live database directly — it's a pure JSON
+// transform so you can review the diff before importing.
+
+import { readFileSync, writeFileSync } from 'fs'
+import path from 'path'
+
+type Counters = Record<string, Record<string, number>> // contextUri -> songId -> count
+type UserBucket = { plays?: Counters; skips?: Counters; [k: string]: unknown }
+
+function mergeCounters (into: Counters, from: Counters | undefined) {
+	if (!from) return
+	for (const [ctx, songs] of Object.entries(from)) {
+		if (!songs || typeof songs !== 'object') continue
+		into[ctx] = into[ctx] || {}
+		for (const [song, count] of Object.entries(songs)) {
+			const n = Number(count)
+			if (Number.isFinite(n)) into[ctx][song] = (into[ctx][song] || 0) + n
+		}
+	}
+}
+
+function main () {
+	const target = process.argv[2]
+	if (!target) {
+		console.error('Usage: ts-node scripts/consolidate-uids.ts <spotifyUserId>')
+		process.exit(1)
+	}
+
+	const inputPath = path.join(__dirname, 'users-export.json')
+	const outputPath = path.join(__dirname, 'users-merged.json')
+
+	const raw = JSON.parse(readFileSync(inputPath, 'utf8')) as Record<string, UserBucket>
+
+	const merged: UserBucket = { plays: {}, skips: {} }
+	const sourceKeys = Object.keys(raw)
+
+	for (const key of sourceKeys) {
+		const bucket = raw[key]
+		if (!bucket || typeof bucket !== 'object') continue
+		mergeCounters(merged.plays as Counters, bucket.plays as Counters | undefined)
+		mergeCounters(merged.skips as Counters, bucket.skips as Counters | undefined)
+		// Preserve unknown fields from the target bucket itself
+		if (key === target) {
+			for (const [k, v] of Object.entries(bucket)) {
+				if (k !== 'plays' && k !== 'skips') merged[k] = v
+			}
+		}
+	}
+
+	const out: Record<string, UserBucket> = { [target]: merged }
+	writeFileSync(outputPath, JSON.stringify(out, null, '\t'))
+
+	const playCtxs = Object.keys(merged.plays || {}).length
+	const skipCtxs = Object.keys(merged.skips || {}).length
+	console.log(`Merged ${sourceKeys.length} source buckets → users/${target}`)
+	console.log(`  plays: ${playCtxs} playlist contexts`)
+	console.log(`  skips: ${skipCtxs} playlist contexts`)
+	console.log(`Output: ${outputPath}`)
+	console.log('Next: upload via Firebase console → Realtime Database → /users → ⋮ → "Import JSON".')
+}
+
+main()

--- a/src/actions/user.ts
+++ b/src/actions/user.ts
@@ -8,5 +8,7 @@ export default {
 	loadUser: makeActionCreator()('LOAD_USER'),
 	userLoaded: makeActionCreator<Optional<User, 'settings'>>()('USER_LOADED'),
 	logout: makeActionCreator()('USER_LOGOUT'),
-	updateSettings: makeActionCreator<any, keyof User['settings']>()('USER_SETTINGS_UPDATE')
+	updateSettings: makeActionCreator<any, keyof User['settings']>()('USER_SETTINGS_UPDATE'),
+	authCheckStart: makeActionCreator()('AUTH_CHECK_START'),
+	authCheckDone: makeActionCreator()('AUTH_CHECK_DONE')
 }

--- a/src/components/layout/App.tsx
+++ b/src/components/layout/App.tsx
@@ -12,6 +12,7 @@ import '~/styles/main.scss'
 import { State } from '~/types'
 import Alerts from '../Alerts'
 import { SilentErrorBoundary } from '../ErrorBoundary'
+import Loading from '../Loading'
 import Notifications from '../Notifications'
 import { ReloadPrompt } from '../ReloadPrompt'
 import Auth from './Auth'
@@ -20,6 +21,7 @@ import { Header } from './Header'
 
 const App: React.FC = () => {
 	const user = useSelector((s: State) => s.user)
+	const authChecking = useSelector((s: State) => s.auth.checking)
 
 	return (
 		<>
@@ -37,6 +39,8 @@ const App: React.FC = () => {
 							<Route path="/tracks/:id" element={<TrackRoute />} />
 							<Route path="*" element={<NotFound />} />
 						</Routes>
+					) : authChecking ? (
+						<Loading />
 					) : (
 						<Auth />
 					)}

--- a/src/reducers/auth.ts
+++ b/src/reducers/auth.ts
@@ -1,0 +1,23 @@
+import { Action } from '~/actions'
+
+export type AuthState = {
+	checking: boolean
+}
+
+// Start in `checking` so the very first paint shows a spinner instead of the
+// login button — Root.tsx dispatches loadUser() synchronously, which resolves
+// to either authCheckDone or userLoaded shortly after.
+const initialState: AuthState = { checking: true }
+
+export default function auth (state: AuthState = initialState, action: Action): AuthState {
+	switch (action.type) {
+		case 'AUTH_CHECK_START':
+			return { checking: true }
+		case 'AUTH_CHECK_DONE':
+		case 'USER_LOADED':
+		case 'USER_LOGOUT':
+			return { checking: false }
+		default:
+			return state
+	}
+}

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -1,3 +1,4 @@
+import auth from './auth'
 import filters from './filters'
 import modals from './modals'
 import notifications from './notifications'
@@ -7,4 +8,4 @@ import song from './song'
 import timer from './timer'
 import user from './user'
 
-export { filters, modals, notifications, playback, playlists, timer, user, song }
+export { auth, filters, modals, notifications, playback, playlists, timer, user, song }

--- a/src/sagas/login.ts
+++ b/src/sagas/login.ts
@@ -1,9 +1,8 @@
-import { signInAnonymously } from 'firebase/auth'
 import { replace } from 'redux-first-history'
-import { call, put, takeLatest } from 'typed-redux-saga'
+import { call, fork, put, takeLatest } from 'typed-redux-saga'
 import { Action, Actions } from '~/actions'
+import { ensureFirebaseReady, migrateLegacyUidData, resetFirebaseAuth, setSpotifyId } from '~/utils/firebase'
 import { clearTokens, exchangeCodeForToken, refreshAccessToken, storeTokens } from '~/utils/spotifyAuth'
-import { auth } from '../utils/firebase'
 import { spotifyFetch } from './spotifyFetch'
 
 export function* loginSaga () {
@@ -14,15 +13,15 @@ export function* loginSaga () {
 }
 
 function* exchangeCode (action: Action<typeof Actions.codeReceived.type>) {
+	yield* put(Actions.authCheckStart())
 	try {
 		const tokens = yield* call(exchangeCodeForToken, action.payload)
 		storeTokens(tokens)
 		yield* put(Actions.tokenAquired(tokens.access_token, action.meta))
 	} catch (e) {
 		console.error(`${exchangeCode.name}:`, e)
-		yield* put(
-			Actions.createNotification({ message: `Login failed: ${(e as Error).message}`, type: 'warning' })
-		)
+		yield* put(Actions.authCheckDone())
+		yield* put(Actions.createNotification({ message: `Login failed: ${(e as Error).message}`, type: 'warning' }))
 	}
 }
 
@@ -32,21 +31,28 @@ function* getUserDetails (action: Action<typeof Actions.tokenAquired.type>) {
 	try {
 		const body = yield* call(() => spotifyFetch<SpotifyApi.UserObjectPublic>('me', {}, token))
 		if (body) {
-			const firebaseUser = yield* call(signInAnonymously, auth)
-
+			// spotifyFetch may have refreshed the access token during /me — read
+			// the freshest token back from localStorage so we don't seed the
+			// store with an already-expired one.
+			const spotifyToken = localStorage.getItem('token') || token
+			// Register the Spotify id with the firebase layer BEFORE the user
+			// is published — useFirebase hooks fire as soon as React re-renders
+			// with a non-null user, and they need the mapping to be in flight.
+			yield* call(setSpotifyId, body.id)
 			yield* put(
 				Actions.userLoaded({
-					...firebaseUser.user,
+					uid: body.id,
 					name: body.display_name || null,
-					spotifyToken: token,
+					spotifyToken,
 					spotify: {
 						...body,
-						image: body.images ? body.images[0].url : null
+						image: body.images?.[0]?.url ?? null
 					}
 				})
 			)
+			yield* fork(firebaseAuthBackground, body.id)
+			yield* put(Actions.fetchPlaylists())
 		}
-		yield* put(Actions.fetchPlaylists())
 		const redirect = action.meta
 		if (redirect && redirect !== location.pathname) {
 			console.info(`Redirecting to ${redirect} from ${location.pathname}`)
@@ -54,10 +60,19 @@ function* getUserDetails (action: Action<typeof Actions.tokenAquired.type>) {
 		}
 	} catch (e) {
 		console.error(`${getUserDetails.name}:`, e)
-		yield put(
+		yield* put(
 			Actions.createNotification({ message: `${getUserDetails.name}: ${(e as Error).message}`, type: 'warning' })
 		)
+	} finally {
+		yield* put(Actions.authCheckDone())
 	}
+}
+
+function* firebaseAuthBackground (spotifyId: string) {
+	const fbUid = yield* call(ensureFirebaseReady)
+	if (!fbUid) return
+	// Salvage anything this anon uid previously wrote at users/<fbUid>/...
+	yield* call(migrateLegacyUidData, spotifyId)
 }
 
 function* loadUser (_: Action<typeof Actions.loadUser.type>) {
@@ -65,21 +80,25 @@ function* loadUser (_: Action<typeof Actions.loadUser.type>) {
 	const refreshToken = localStorage.getItem('refresh_token')
 
 	if (token) {
-		yield* call(signInAnonymously, auth)
+		// authCheckDone is dispatched by the resulting getUserDetails
 		yield* put(Actions.tokenAquired(token, null))
-	} else if (refreshToken) {
+		return
+	}
+	if (refreshToken) {
 		try {
 			const tokens = yield* call(refreshAccessToken, refreshToken)
 			storeTokens(tokens)
-			yield* call(signInAnonymously, auth)
 			yield* put(Actions.tokenAquired(tokens.access_token, null))
+			return
 		} catch (e) {
 			console.warn('Failed to refresh token on load:', e)
 			clearTokens()
 		}
 	}
+	yield* put(Actions.authCheckDone())
 }
 
 function* onLogout (_: Action<typeof Actions.logout.type>) {
 	yield* call(clearTokens)
+	yield* call(resetFirebaseAuth)
 }

--- a/src/sagas/nowPlaying.ts
+++ b/src/sagas/nowPlaying.ts
@@ -13,6 +13,7 @@ export function* nowPlayingSaga () {
 
 function* clearSkips (action: Action<'PLAYBACK_CLEAR_SKIPS'>) {
 	const user = yield* select((s: State) => s.user as User) // User will not be null when playback is active
+	if (!user.uid) return // Firebase anon-auth hasn't landed yet; skip the RTDB write
 	yield* call(() => firebaseUpdate(`users/${user.uid}/skips/${action.meta}/${action.payload}/`, 0))
 }
 
@@ -89,23 +90,27 @@ function* onPlaybackUpdated (action: Action<'PLAYBACK_UPDATED'>) {
 	const progress_ms = current.progress_ms ?? 0
 	const percent = (progress_ms / song.duration_ms) * 100
 
-	const plays = yield* call(() => firebaseGet(`users/${user.uid}/plays/${context?.uri || 'unknown'}/${song.id}/`))
+	if (user.uid) {
+		const plays = yield* call(() => firebaseGet(`users/${user.uid}/plays/${context?.uri || 'unknown'}/${song.id}/`))
 
-	yield* call(() =>
-		firebaseUpdate(`users/${user.uid}/plays/${context?.uri || 'unknown'}/${song.id}/`, (plays ?? 0) + 1)
-	)
+		yield* call(() =>
+			firebaseUpdate(`users/${user.uid}/plays/${context?.uri || 'unknown'}/${song.id}/`, (plays ?? 0) + 1)
+		)
+	}
 
 	if (user.settings.watchSkips) {
 		// Detect skip based on seconds left in song and percent completed
 		if (song.duration_ms - progress_ms > 10000 && percent < 80) {
 			yield put(Actions.songSkipped(song, context))
 
-			const skips = yield* call(() =>
-				firebaseGet(`users/${user.uid}/skips/${context?.uri || 'unknown'}/${song.id}/`)
-			)
-			yield* call(() =>
-				firebaseUpdate(`users/${user.uid}/skips/${context?.uri || 'unknown'}/${song.id}/`, (skips ?? 0) + 1)
-			)
+			if (user.uid) {
+				const skips = yield* call(() =>
+					firebaseGet(`users/${user.uid}/skips/${context?.uri || 'unknown'}/${song.id}/`)
+				)
+				yield* call(() =>
+					firebaseUpdate(`users/${user.uid}/skips/${context?.uri || 'unknown'}/${song.id}/`, (skips ?? 0) + 1)
+				)
+			}
 		}
 		if (percent < 90) {
 			yield* put(

--- a/src/sagas/spotifyFetch.ts
+++ b/src/sagas/spotifyFetch.ts
@@ -3,7 +3,7 @@ import { call, put, select } from 'typed-redux-saga'
 import { Actions } from '~/actions'
 import { State } from '~/types'
 import { sleep } from '~/utils'
-import { refreshAccessToken, storeTokens } from '~/utils/spotifyAuth'
+import { refreshAccessToken, RefreshTokenRejected, storeTokens } from '~/utils/spotifyAuth'
 
 // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-constraint
 export function* spotifyFetch<T extends unknown> (
@@ -44,6 +44,13 @@ export function* spotifyFetch<T extends unknown> (
 					return next as T | null
 				} catch (e) {
 					console.error('Token refresh failed:', e)
+					// Only nuke session when Spotify actually rejected the refresh
+					// token. Transient network errors (offline, DNS, etc.) should
+					// surface as a fetch failure — the next call can retry.
+					if (e instanceof RefreshTokenRejected) {
+						yield* put(Actions.logout())
+					}
+					throw e instanceof Error ? e : new Error(String(e))
 				}
 			}
 			yield* put(Actions.logout())

--- a/src/sagas/tracks.ts
+++ b/src/sagas/tracks.ts
@@ -47,12 +47,13 @@ export function* getTracks (action: Action<'FETCH_TRACKS'>) {
 	const id = action.meta
 	const limit = 100
 	const user = yield* select((s: State) => s.user)
-	let plays: Nullable<SongEntries>
-	try {
-		plays = yield* call(() => firebaseGet(`users/${user?.uid}/plays/spotify:playlist:${id}/`))
-	} catch (e) {
-		plays = null
-		console.warn(`Error fetching plays from firebase 'users/${user?.uid}/plays/spotify:playlist:${id}/'`, e)
+	let plays: Nullable<SongEntries> = null
+	if (user?.uid) {
+		try {
+			plays = yield* call(() => firebaseGet(`users/${user.uid}/plays/spotify:playlist:${id}/`))
+		} catch (e) {
+			console.warn(`Error fetching plays from firebase 'users/${user.uid}/plays/spotify:playlist:${id}/'`, e)
+		}
 	}
 
 	const fetchPage = (offset: number) =>

--- a/src/types/spotify.ts
+++ b/src/types/spotify.ts
@@ -1,4 +1,3 @@
-import { User as FirebaseUser } from 'firebase/auth'
 import { SongEntries } from './firebase'
 import { Nullable } from './helpers'
 
@@ -14,7 +13,10 @@ export interface Playlist extends Omit<SpotifyApi.PlaylistObjectFull, 'tracks' |
 	uri: `spotify:playlist:${string}`
 }
 
-export interface User extends FirebaseUser {
+export interface User {
+	// Firebase anonymous-auth uid. Empty string until anon-auth completes (which
+	// runs off the Spotify-login critical path). RTDB ops gate on a non-empty uid.
+	uid: string
 	name: string | null
 	spotifyToken: string
 

--- a/src/utils/firebase.ts
+++ b/src/utils/firebase.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-restricted-imports */
 import { FirebaseOptions, initializeApp } from 'firebase/app'
-import { initializeAuth, inMemoryPersistence } from 'firebase/auth'
-import { get, getDatabase, onValue, ref, update } from 'firebase/database'
+import { browserLocalPersistence, initializeAuth, inMemoryPersistence, signInAnonymously } from 'firebase/auth'
+import { get, getDatabase, onValue, ref, remove, update } from 'firebase/database'
 import { FirebaseGet, FirebaseUpdates, FirebaseUrls } from '~/types'
 
 const PROJECT_ID = process.env.PACKAGE_NAME
@@ -20,31 +20,156 @@ const firebaseConfig: FirebaseOptions = {
 
 const app = initializeApp(firebaseConfig)
 const db = getDatabase(app)
-// IndexedDB-backed auth persistence can deadlock when the firebaseLocalStorageDb
-// is held open elsewhere — signInAnonymously then never fires its network
-// request. We re-auth anonymously on every load anyway, so in-memory works.
-export const auth = initializeAuth(app, { persistence: inMemoryPersistence })
+// Persistence priority:
+//   1. browserLocalPersistence (localStorage) — survives reloads so the
+//      anonymous uid is stable across sessions.
+//   2. inMemoryPersistence — fallback for browsers/contexts where localStorage
+//      is unavailable.
+// Deliberately skipping indexedDBLocalPersistence (Firebase's default): its
+// firebaseLocalStorageDb can deadlock when held open by another tab/SW.
+export const auth = initializeAuth(app, {
+	persistence: [browserLocalPersistence, inMemoryPersistence]
+})
+
+// Identity model:
+//   - Data is keyed by the Spotify user id (stable across logins and devices).
+//   - RTDB rules require an authenticated Firebase user whose anon uid maps to
+//     that Spotify id via `uidMap/<firebaseUid> = <spotifyId>`.
+//   - We write the mapping once per anon uid, which lets the same Spotify
+//     identity be reachable from multiple anonymous Firebase sessions.
+
+const RETRY_DELAYS_MS = [500, 1500, 4000, 10000]
+let readyPromise: Promise<string | null> | null = null
+let cachedFirebaseUid: string | null = null
+let pendingSpotifyId: string | null = null
+
+async function attemptAnonymousAuth (): Promise<string | null> {
+	for (let attempt = 0; attempt <= RETRY_DELAYS_MS.length; attempt++) {
+		try {
+			const result = await signInAnonymously(auth)
+			cachedFirebaseUid = result.user.uid
+			return cachedFirebaseUid
+		} catch (e) {
+			const delay = RETRY_DELAYS_MS[attempt]
+			if (delay === undefined) {
+				console.error('Firebase anonymous auth gave up after retries:', e)
+				return null
+			}
+			console.warn(`Firebase anonymous auth failed (attempt ${attempt + 1}); retrying in ${delay}ms`, e)
+			await new Promise(r => setTimeout(r, delay))
+		}
+	}
+	return null
+}
+
+async function attemptReady (): Promise<string | null> {
+	const fbUid = await attemptAnonymousAuth()
+	if (!fbUid || !pendingSpotifyId) return fbUid
+	try {
+		await update(ref(db), { [`uidMap/${fbUid}`]: pendingSpotifyId })
+	} catch (e) {
+		console.error('Failed to write uidMap; user-data RTDB ops will be denied by rules', e)
+		return null
+	}
+	return fbUid
+}
+
+// Call before any RTDB user-data op so the uidMap can be written before the op
+// is gated by rules. Synchronous and idempotent.
+export function setSpotifyId (id: string) {
+	if (pendingSpotifyId === id) return
+	pendingSpotifyId = id
+	// Force a fresh ready cycle so the new mapping is written even if anon
+	// auth already completed without a spotify id.
+	if (cachedFirebaseUid) readyPromise = null
+}
+
+export function ensureFirebaseReady (): Promise<string | null> {
+	if (!readyPromise) {
+		readyPromise = attemptReady().finally(() => {
+			if (!cachedFirebaseUid) readyPromise = null
+		})
+	}
+	return readyPromise
+}
+
+export function getFirebaseUid (): string | null {
+	return cachedFirebaseUid
+}
+
+export function resetFirebaseAuth () {
+	cachedFirebaseUid = null
+	pendingSpotifyId = null
+	readyPromise = null
+}
 
 export function firebaseWatch<T extends FirebaseUrls> (url: T, onUpdate: (value: FirebaseGet<T>) => void) {
 	const key = url.endsWith('/') ? url.slice(0, -1) : url
-	const resource = ref(db, key)
+	let cancelled = false
+	let unsubscribe: (() => void) | null = null
 
-	onValue(resource, snapshot => {
-		onUpdate(snapshot.val())
+	ensureFirebaseReady().then(uid => {
+		if (cancelled || !uid) return
+		unsubscribe = onValue(ref(db, key), snapshot => {
+			onUpdate(snapshot.val())
+		})
 	})
+
+	return () => {
+		cancelled = true
+		if (unsubscribe) unsubscribe()
+	}
 }
 
 export async function firebaseGet<T extends FirebaseUrls> (url: T): Promise<FirebaseGet<T> | null> {
+	const uid = await ensureFirebaseReady()
+	if (!uid) return null
 	const key = url.endsWith('/') ? url.slice(0, -1) : url
 	const res = await get(ref(db, key))
 	return res.val()
 }
 
 export async function firebaseUpdate<T extends FirebaseUrls> (url: T, value: unknown) {
+	const uid = await ensureFirebaseReady()
+	if (!uid) return
 	const key = url.endsWith('/') ? url.slice(0, -1) : url
 	return update(ref(db), { [key]: value })
 }
 
 export async function firebaseUpdateMultiple (updates: FirebaseUpdates) {
+	const uid = await ensureFirebaseReady()
+	if (!uid) return
 	return update(ref(db), updates)
+}
+
+// One-shot self-migration: if this Firebase anon uid had previously written
+// data at users/<firebaseUid>/..., merge it into users/<spotifyId>/... and
+// delete the old node. Only rescues data that this browser/device can
+// authenticate as — orphaned uids from past inMemoryPersistence sessions
+// require the admin script under scripts/migrate-firebase-uids.ts.
+export async function migrateLegacyUidData (spotifyId: string): Promise<void> {
+	const fbUid = await ensureFirebaseReady()
+	if (!fbUid || fbUid === spotifyId) return
+
+	const legacy = await get(ref(db, `users/${fbUid}`))
+	const data = legacy.val()
+	if (!data) return
+
+	const flat: Record<string, unknown> = {}
+	const walk = (node: unknown, path: string[]) => {
+		if (node === null || typeof node !== 'object') {
+			flat[['users', spotifyId, ...path].join('/')] = node
+			return
+		}
+		for (const [k, v] of Object.entries(node as Record<string, unknown>)) walk(v, [...path, k])
+	}
+	walk(data, [])
+
+	try {
+		await update(ref(db), flat)
+		await remove(ref(db, `users/${fbUid}`))
+		console.info(`Migrated ${Object.keys(flat).length} legacy fields from users/${fbUid} → users/${spotifyId}`)
+	} catch (e) {
+		console.warn('Legacy uid migration failed (non-fatal):', e)
+	}
 }

--- a/src/utils/hooks.ts
+++ b/src/utils/hooks.ts
@@ -20,8 +20,12 @@ export function useMapDispatch<T extends Record<string, ActionCreator>> (actions
 export function useFirebase<T extends FirebaseUrls> (url: T) {
 	const [data, setData] = useState<FirebaseGet<T> | null>(null)
 	useEffect(() => {
+		// Skip until the URL has a real uid — callers commonly pass
+		// `users/${user?.uid}/...` which produces "users/undefined/..." or
+		// "users//..." during the brief window before Firebase anon-auth lands.
+		if (url.includes('/undefined/') || url.includes('//')) return
 		firebaseGet(url).then(setData)
-		firebaseWatch(url, setData)
+		return firebaseWatch(url, setData)
 	}, [url])
 	return data
 }

--- a/src/utils/spotifyAuth.ts
+++ b/src/utils/spotifyAuth.ts
@@ -83,6 +83,12 @@ export async function exchangeCodeForToken (code: string): Promise<TokenResponse
 	return res.json()
 }
 
+export class RefreshTokenRejected extends Error {
+	constructor (public status: number, body: string) {
+		super(`Refresh token rejected (${status}): ${body}`)
+	}
+}
+
 export async function refreshAccessToken (refreshToken: string): Promise<TokenResponse> {
 	const body = new URLSearchParams({
 		grant_type: 'refresh_token',
@@ -90,12 +96,15 @@ export async function refreshAccessToken (refreshToken: string): Promise<TokenRe
 		client_id: CLIENT_ID
 	})
 
+	// Network errors (fetch rejects) bubble as-is; HTTP errors map to
+	// RefreshTokenRejected so callers can distinguish "Spotify said no" from
+	// "we couldn't reach Spotify".
 	const res = await fetch(TOKEN_ENDPOINT, {
 		method: 'POST',
 		headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
 		body
 	})
-	if (!res.ok) throw new Error(`Token refresh failed: ${res.status}`)
+	if (!res.ok) throw new RefreshTokenRejected(res.status, await res.text())
 	return res.json()
 }
 


### PR DESCRIPTION
## Summary

- **Decouples Spotify login from Firebase anon-auth.** A flaky `identitytoolkit.googleapis.com` request (ad-blocker, DNS, etc.) no longer hangs the login saga and traps users on the "Log in to Spotify" button despite valid tokens in localStorage. Anon-auth retries 4× in the background and degrades play/skip tracking gracefully if it never succeeds.
- **Stabilizes the data identity.** Plays/skips are now keyed by Spotify user id (stable across logins and devices) instead of the ephemeral Firebase anon uid. A `uidMap` subtree in the RTDB rules attests `auth.uid → spotifyId` so the same Spotify identity is reachable from any anon session.
- **Fixes anon-uid rotation on every reload.** Persistence moves from `inMemoryPersistence` to `[browserLocal, inMemory]` — same uid across cold loads, no IndexedDB so no deadlock.
- **Salvage path for orphaned data.** Adds `scripts/consolidate-uids.ts`: offline JSON transform that merges every legacy anon-uid bucket's `plays`/`skips` counters into one `users/<spotifyId>/` bucket. Export from Firebase Console → run → re-import.

Secondary fixes bundled:
- Token refresh during `/me` no longer seeds redux with a stale access token.
- Refresh failures distinguish `RefreshTokenRejected` (4xx → logout) from network errors (transient → bubble up, no logout).
- App.tsx renders a loading spinner on cold loads instead of flashing the login button.

## Why now

Reported symptom was \"I have to press 'Log in to Spotify' every time.\" Captured `auth/network-request-failed` from `signInAnonymously` in the console — the request to `identitytoolkit.googleapis.com` never made the wire (zero entries in the HAR), which matches a client-side block (uBlock default lists, NextDNS, Brave Shields all carry that host). PR #82's IndexedDB-deadlock fix didn't help because the failure mode was further upstream — the saga had no try/catch around `signInAnonymously`, and it was on the critical path of \"is the user logged in to Spotify?\".

The persistence change in #82 also caused a separate, less-visible problem: every reload minted a new anon uid, so the per-user RTDB rule `\$uid === auth.uid` quietly orphaned plays/skips from prior sessions. The fix above plus the consolidation script recover from that.

## RTDB rules diff

```json
{
  \"rules\": {
    \"uidMap\": {
      \"\$firebaseUid\": {
        \".read\":  \"\$firebaseUid === auth.uid\",
        \".write\": \"\$firebaseUid === auth.uid\",
        \".validate\": \"newData.isString() && newData.val().length > 0 && newData.val().length < 256\"
      }
    },
    \"users\": {
      \"\$key\": {
        \".read\":  \"auth != null && (\$key === auth.uid || root.child('uidMap').child(auth.uid).val() === \$key)\",
        \".write\": \"auth != null && (\$key === auth.uid || root.child('uidMap').child(auth.uid).val() === \$key)\"
      }
    }
  }
}
```

`\$key === auth.uid` is preserved so the in-app self-migration can read the current anon uid's legacy bucket and copy it into `users/<spotifyId>/`. Once everyone has migrated, that clause can be removed.

## Test plan

- [ ] Cold load with valid Spotify tokens in localStorage → no login-button flash, goes straight to playlists.
- [ ] Cold load with expired access token → silent refresh, no logout, no flash.
- [ ] Cold load with `identitytoolkit.googleapis.com` blocked (uBlock rule) → Spotify UI fully usable, only Dashboard play/skip counts are missing.
- [ ] Play a song, skip another → verify writes land at `users/<spotifyId>/plays/<ctx>/<id>` and `users/<spotifyId>/skips/<ctx>/<id>` (Firebase Console).
- [ ] Verify `uidMap/<firebaseUid> = <spotifyId>` is written once per anon uid.
- [ ] Hard reload → same anon uid, same Spotify id, same data visible on Dashboard.
- [ ] Run `scripts/consolidate-uids.ts` against a `/users` export, diff before/after, re-import, confirm Dashboard totals match the pre-import sum.

🤖 Generated with [Claude Code](https://claude.com/claude-code)