### PR TITLE
fix(tracks): stop track-load cascade and use cache properly

### DIFF
--- a/__tests__/sagas/tracks.test.ts
+++ b/__tests__/sagas/tracks.test.ts
@@ -1,0 +1,123 @@
+import { runSaga, stdChannel } from 'redux-saga'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('~/sagas/spotifyFetch', () => ({
+	spotifyFetch: vi.fn()
+}))
+
+vi.mock('~/utils/firebase', () => ({
+	firebaseGet: vi.fn().mockResolvedValue(null),
+	firebaseUpdate: vi.fn().mockResolvedValue(undefined),
+	firebaseWatch: vi.fn(() => () => undefined),
+	ensureFirebaseReady: vi.fn().mockResolvedValue(null),
+	resetFirebaseAuth: vi.fn(),
+	getFirebaseUid: vi.fn(() => null),
+	setSpotifyId: vi.fn(),
+	migrateLegacyUidData: vi.fn(),
+	auth: {}
+}))
+
+// PlaylistCache/SongCache normally back onto localforage → IndexedDB, which
+// jsdom can run but slowly. Stub them with plain Maps + a resolved ready
+// promise so the saga's `PlaylistCache.ready` await returns immediately.
+vi.mock('~/utils/Cache', () => {
+	class FakeCache<T> extends Map<string, T> {
+		public readonly ready = Promise.resolve()
+		public id: string
+		constructor (id: string) {
+			super()
+			this.id = id
+		}
+	}
+	return { PersistentCache: FakeCache }
+})
+
+import { Actions } from '~/actions'
+import { spotifyFetch } from '~/sagas/spotifyFetch'
+import { getTracks } from '~/sagas/tracks'
+
+const trackPage = (offset: number, total: number, count: number) => ({
+	items: Array.from({ length: count }, (_, i) => ({
+		track: {
+			id: `track-${offset + i}`,
+			name: `Track ${offset + i}`,
+			uri: `spotify:track:track-${offset + i}`,
+			artists: [{ id: 'a1', name: 'Artist', uri: 'spotify:artist:a1' }],
+			album: { id: 'al1', name: 'Album', uri: 'spotify:album:al1', images: [] },
+			duration_ms: 1000
+		},
+		added_at: '2026-01-01',
+		added_by: { id: 'u1' },
+		is_local: false
+	})),
+	total,
+	href: '',
+	limit: 100,
+	offset,
+	next: null,
+	previous: null
+})
+
+const baseIo = (overrides: Record<string, unknown> = {}) => ({
+	channel: stdChannel(),
+	dispatch: vi.fn(),
+	getState: () => ({
+		user: { uid: null, spotifyToken: 'tok' },
+		playlists: [{ id: 'p1', uri: 'spotify:playlist:p1', name: 'P1', snapshot_id: 's1', tracks: { total: 250 } }],
+		...overrides
+	})
+})
+
+describe('getTracks', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+	})
+
+	it('dedupes concurrent invocations for the same playlist id', async () => {
+		// Slow the playlist track endpoint so the second invocation races against
+		// the first. `playlists/<id>` (used by updateProgress when state lacks the
+		// playlist) is fast and unrelated.
+		;(spotifyFetch as ReturnType<typeof vi.fn>).mockImplementation(async (url: string) => {
+			if (url.includes('/tracks?')) {
+				await new Promise(r => setTimeout(r, 25))
+				const m = url.match(/offset=(\d+)/)
+				const off = m ? parseInt(m[1], 10) : 0
+				return trackPage(off, 250, 100)
+			}
+			return null
+		})
+
+		const io = baseIo()
+		const tasks = Array.from({ length: 5 }, () => runSaga(io, getTracks, Actions.fetchTracks('p1')))
+		await Promise.all(tasks.map(t => t.toPromise()))
+
+		// Page count: ceil(250/100) = 3 pages. Five concurrent dispatches must not
+		// multiply the network: only the first invocation should fetch.
+		const trackFetches = (spotifyFetch as ReturnType<typeof vi.fn>).mock.calls.filter(c =>
+			String(c[0]).includes('/tracks?')
+		)
+		expect(trackFetches).toHaveLength(3)
+	})
+
+	it('fans out remaining pages in parallel after page 0', async () => {
+		const callTimes: number[] = []
+		;(spotifyFetch as ReturnType<typeof vi.fn>).mockImplementation(async (url: string) => {
+			if (url.includes('/tracks?')) {
+				callTimes.push(Date.now())
+				await new Promise(r => setTimeout(r, 20))
+				const m = url.match(/offset=(\d+)/)
+				const off = m ? parseInt(m[1], 10) : 0
+				return trackPage(off, 500, 100)
+			}
+			return null
+		})
+
+		await runSaga(baseIo(), getTracks, Actions.fetchTracks('p2')).toPromise()
+
+		// 5 pages total: page 0 first, pages 100..400 should fire ~simultaneously.
+		expect(callTimes).toHaveLength(5)
+		const afterFirst = callTimes.slice(1)
+		const spread = Math.max(...afterFirst) - Math.min(...afterFirst)
+		expect(spread).toBeLessThan(15)
+	})
+})

--- a/src/sagas/tracks.ts
+++ b/src/sagas/tracks.ts
@@ -4,6 +4,12 @@ import { Nullable, Playlist, SongEntries, State, Track, URI } from '~/types'
 import { firebaseGet, idToUri, PlaylistCache, SongCache, toTrack } from '~/utils'
 import { spotifyFetch } from './spotifyFetch'
 
+// Dedupes concurrent `getTracks` invocations for the same playlist id. Several
+// call sites can race here — `usePlaylist` on the route, `getAllTracks` on the
+// playlists-fetched fan-out, `deleteTracks` after a mutation — and `takeEvery`
+// gives no in-flight protection on its own.
+const inFlight = new Set<Playlist['id']>()
+
 export function* tracksSaga () {
 	yield* takeEvery(Actions.fetchTrack.type, getTrack)
 	yield* takeEvery(Actions.fetchTracks.type, getTracks)
@@ -11,6 +17,11 @@ export function* tracksSaga () {
 }
 
 function* getAllTracks (action: Action<'FETCH_PLAYLISTS_SUCCESS'>) {
+	// PlaylistCache hydration is async — without this wait, the very first
+	// session after a reload reads an empty Map and refetches every playlist
+	// from Spotify, even when fully cached locally.
+	yield* call(() => PlaylistCache.ready)
+
 	for (const playlist of action.payload) {
 		const existing = PlaylistCache.get(playlist.uri as URI<'playlist'>)
 		if (existing) {
@@ -43,97 +54,104 @@ export function* getTrack (action: Action<'FETCH_TRACK'>) {
 	yield put(Actions.createNotification({ message: 'Error fetching track', type: 'error' }))
 }
 
+function* fetchPlays (uid: string | null | undefined, id: Playlist['id']): Generator<unknown, Nullable<SongEntries>> {
+	if (!uid) return null
+	try {
+		return yield* call(() => firebaseGet(`users/${uid}/plays/spotify:playlist:${id}/`))
+	} catch (e) {
+		console.warn(`Error fetching plays from firebase 'users/${uid}/plays/spotify:playlist:${id}/'`, e)
+		return null
+	}
+}
+
 export function* getTracks (action: Action<'FETCH_TRACKS'>) {
 	const id = action.meta
-	const limit = 100
-	const user = yield* select((s: State) => s.user)
-	let plays: Nullable<SongEntries> = null
-	if (user?.uid) {
-		try {
-			plays = yield* call(() => firebaseGet(`users/${user.uid}/plays/spotify:playlist:${id}/`))
-		} catch (e) {
-			console.warn(`Error fetching plays from firebase 'users/${user.uid}/plays/spotify:playlist:${id}/'`, e)
-		}
-	}
-
-	const fetchPage = (offset: number) =>
-		spotifyFetch<SpotifyApi.PlaylistTrackResponse>(`playlists/${id}/tracks?offset=${offset}&limit=${limit}`)
-
-	let first: SpotifyApi.PlaylistTrackResponse | null
+	if (inFlight.has(id)) return
+	inFlight.add(id)
 	try {
-		first = yield* call(fetchPage, 0)
-	} catch (e: any) {
-		yield* put(Actions.createNotification({ message: e.message, type: 'error' }))
-		return
-	}
-	if (first === null) return
-	const total = first.total
+		const limit = 100
+		const user = yield* select((s: State) => s.user)
 
-	const remainingOffsets: number[] = []
-	for (let o = limit; o < total; o += limit) remainingOffsets.push(o)
+		const fetchPage = (offset: number) =>
+			spotifyFetch<SpotifyApi.PlaylistTrackResponse>(`playlists/${id}/tracks?offset=${offset}&limit=${limit}`)
 
-	let completed = first.items.length
-	yield* put(Actions.fetchTracksProgress(completed, id))
-
-	function* fetchPageReport (offset: number) {
-		const page = yield* call(fetchPage, offset)
-		if (page) {
-			completed = Math.min(completed + page.items.length, total)
-			yield* put(Actions.fetchTracksProgress(completed, id))
-		}
-		return page
-	}
-
-	let rest: Array<SpotifyApi.PlaylistTrackResponse | null> = []
-	if (remainingOffsets.length > 0) {
+		// Page 0 and the plays lookup are independent — running them in parallel
+		// saves up to ~16s on cold starts where Firebase anon-auth is retrying.
+		let first: SpotifyApi.PlaylistTrackResponse | null
+		let plays: Nullable<SongEntries>
 		try {
-			rest = yield* all(remainingOffsets.map(o => call(fetchPageReport, o)))
+			const result = yield* all({
+				first: call(fetchPage, 0),
+				plays: call(fetchPlays, user?.uid, id)
+			})
+			first = result.first
+			plays = result.plays
 		} catch (e: any) {
 			yield* put(Actions.createNotification({ message: e.message, type: 'error' }))
 			return
 		}
-	}
+		if (first === null) return
+		const total = first.total
 
-	const pages = [first, ...rest].filter((p): p is SpotifyApi.PlaylistTrackResponse => p !== null)
-	const tracks: SongEntries = {}
-	let loaded = 0
-	pages.forEach((page, pageIdx) => {
-		const pageOffset = pageIdx * limit
-		const mapped = page.items
-			.filter(t => t.track)
-			.map<Track>((t, i) => toTrack(t, pageOffset + i))
-		mapped.forEach(track => SongCache.set(track.id, track))
-		for (const t of mapped) {
-			tracks[t.id] = plays?.[t.id] || 0
+		const tracks: SongEntries = {}
+		let loaded = 0
+
+		function* processPage (page: SpotifyApi.PlaylistTrackResponse, offset: number) {
+			const mapped = page.items
+				.filter(t => t.track)
+				.map<Track>((t, i) => toTrack(t, offset + i))
+			mapped.forEach(track => SongCache.set(track.id, track))
+			for (const t of mapped) tracks[t.id] = plays?.[t.id] || 0
+			loaded += mapped.length
+			yield* call(updateProgress, id, tracks, loaded, loaded === total)
 		}
-		loaded += mapped.length
-	})
 
-	yield* call(updateProgress, id, tracks, loaded)
+		yield* call(processPage, first, 0)
+
+		const remainingOffsets: number[] = []
+		for (let o = limit; o < total; o += limit) remainingOffsets.push(o)
+
+		if (remainingOffsets.length === 0) return
+
+		function* fetchAndProcess (offset: number) {
+			const page = yield* call(fetchPage, offset)
+			if (page) yield* call(processPage, page, offset)
+		}
+
+		try {
+			yield* all(remainingOffsets.map(o => call(fetchAndProcess, o)))
+		} catch (e: any) {
+			yield* put(Actions.createNotification({ message: e.message, type: 'error' }))
+		}
+	} finally {
+		inFlight.delete(id)
+	}
 }
 
-function* updateProgress (id: Playlist['id'], tracks: SongEntries, loaded: number) {
+function* updateProgress (id: Playlist['id'], tracks: SongEntries, loaded: number, complete: boolean) {
 	let playlist: Nullable<Playlist> = yield* select((s: State) => s.playlists.find(p => p.id === id))
 
 	if (!playlist) playlist = PlaylistCache.get(idToUri(id, 'playlist'))
 	if (!playlist) playlist = yield* call(() => spotifyFetch<Playlist>(`playlists/${id}`))
 
-	if (playlist) {
-		const item: Playlist = {
-			...playlist,
-			tracks: {
-				...playlist.tracks,
-				lastFetched: new Date(),
-				items: tracks,
-				loaded
-			}
+	if (!playlist) return
+
+	const item: Playlist = {
+		...playlist,
+		tracks: {
+			...playlist.tracks,
+			// Only stamp lastFetched on the final write — partial writes must not
+			// look "complete" to consumers like `usePlaylist`'s watch effect.
+			lastFetched: complete ? new Date() : playlist.tracks.lastFetched ?? null,
+			items: tracks,
+			loaded
 		}
-		PlaylistCache.set(playlist.uri, item)
-		if (loaded == item.tracks.total) {
-			console.info(`Tracks for '${playlist.name}' (${playlist.id}) loaded`)
-			yield* put(Actions.tracksFetched(item, id))
-		} else {
-			yield* put(Actions.fetchTracksProgress(loaded, id))
-		}
+	}
+	PlaylistCache.set(playlist.uri, item)
+	if (complete) {
+		console.info(`Tracks for '${playlist.name}' (${playlist.id}) loaded`)
+		yield* put(Actions.tracksFetched(item, id))
+	} else {
+		yield* put(Actions.fetchTracksProgress(loaded, id))
 	}
 }

--- a/src/utils/Cache.ts
+++ b/src/utils/Cache.ts
@@ -6,8 +6,12 @@ type CacheEntry<T, K = string> = Tuple<K, Readonly<T>>
 
 export class PersistentCache<T, K extends string = string> extends Map<K, Readonly<T>> {
 	public id = ''
+	// Resolves when the in-memory Map has been hydrated from localforage.
+	// Callers that decide whether to refetch from network MUST await this; the
+	// Map is empty during the constructor's async load and an unguarded read
+	// looks indistinguishable from "nothing cached".
+	public readonly ready: Promise<void>
 	private db: LocalForage
-	private ready: Promise<void>
 	private pendingKeysWrite: Promise<void> = Promise.resolve()
 
 	constructor (id: string) {

--- a/src/utils/hooks.ts
+++ b/src/utils/hooks.ts
@@ -32,14 +32,24 @@ export function useFirebase<T extends FirebaseUrls> (url: T) {
 
 export function usePlaylist (id: string): Playlist | undefined {
 	const dispatch = useDispatch()
-	const playlists = useAppSelector(s => s.playlists)
-	const [playlist, setPlaylist] = useState(findPlaylist(id) ?? playlists?.find(pl => pl.id == id))
+	// Subscribe to just this playlist's slice so the hook re-renders only when
+	// _this_ playlist changes, not on every progress event for any playlist.
+	const existing = useAppSelector(s => s.playlists?.find(pl => pl.id == id))
+	const [playlist, setPlaylist] = useState(() => findPlaylist(id) ?? existing)
+
+	// Dispatch is keyed on id only — every other dep would risk re-dispatching
+	// during the load (each FETCH_TRACKS_PROGRESS mutates the playlists ref).
+	// The saga dedupes concurrent loads for the same id as defence-in-depth.
 	useEffect(() => {
-		const existing = playlists?.find(pl => pl.id == id)
-		const cached = findPlaylist(id)
-		if (cached === undefined || cached.tracks.loaded == null) {
+		if (findPlaylist(id) === undefined) {
 			dispatch(Actions.fetchTracks(id))
-		} else if (existing?.tracks.lastFetched) {
+		}
+	}, [dispatch, id])
+
+	// Watch for the load to complete. lastFetched flips from null → Date exactly
+	// once, so this effect runs at most twice per id (mount + completion).
+	useEffect(() => {
+		if (existing?.tracks.lastFetched) {
 			setPlaylist(existing)
 			return
 		}
@@ -50,10 +60,8 @@ export function usePlaylist (id: string): Playlist | undefined {
 				setPlaylist(data)
 			}
 		}, 300)
+		return () => window.clearInterval(interval)
+	}, [id, existing?.tracks.lastFetched, existing])
 
-		return () => {
-			window.clearInterval(interval)
-		}
-	}, [dispatch, id, playlists])
 	return playlist
 }


### PR DESCRIPTION
## Summary

Single-playlist navigation was firing 139 requests against one playlist within ~6s on a fresh load (per attached HAR), tripping Spotify 429s along the way. Three independent bugs combined to cause it. This PR fixes all three plus a Firebase-blocking issue that adds up to ~16s to cold starts.

## Root cause

1. **`usePlaylist` cascade.** The effect had `playlists` in its dep array. The playlists reducer creates a new array on every `FETCH_TRACKS_PROGRESS`. With nothing in `PlaylistCache` yet, the gate (`cached === undefined`) stayed true and each re-render fired another `fetchTracks`. `takeEvery` happily spawned a fresh `getTracks` per dispatch, each fanning all pages out in parallel.

2. **`PlaylistCache` was never warmed during a load.** PR #77 moved the `PlaylistCache.set` call from per-page to once-at-end, so `findPlaylist(id)` returned `undefined` for the entire duration of a load — which is what kept the cascade gate open.

3. **`PersistentCache.ready` was private and nobody awaited it.** The Map hydrates from localforage asynchronously; the first reader after a reload saw an empty Map and refetched everything from Spotify even when the data was fully cached locally.

## Fixes

- **`usePlaylist`**: split into two effects. Dispatch keys only on `[dispatch, id]`; the watch effect keys on `existing?.tracks.lastFetched` (stable `null` until completion). The selector subscribes to just this playlist's slice so the hook re-renders only when this playlist changes.
- **`tracks` saga**: process each page incrementally via a shared accumulator, so `PlaylistCache` and the redux progress action both update on every page (not just at the end). `updateProgress` takes a `complete` flag and only stamps `lastFetched` on the final write — partial writes must not look done to the watch effect.
- **In-flight `Set`** in `tracks` saga short-circuits `getTracks` if it's already running for that id. Defence-in-depth against any future caller that dispatches `fetchTracks` redundantly.
- **Page 0 + Firebase plays lookup run in parallel** via `yield* all({...})` instead of sequentially. Saves up to ~16s on cold starts where Firebase anon-auth is retrying behind an ad-blocker / DNS failure (the `attemptAnonymousAuth` retry budget is `500+1500+4000+10000`).
- **`PersistentCache.ready` is now `public readonly`**; `getAllTracks` awaits it before the snapshot_id comparisons so cold-boot cache hits actually short-circuit refetches.

## Test plan

- [x] `yarn test` (32 passing, includes 2 new tests)
- [x] `yarn lint` clean
- [x] `yarn stylelint` clean
- [x] `yarn prod` builds clean
- [ ] Preview deploy goes green
- [ ] Manual: open a large (>200 track) playlist on a clean session, confirm network shows ceil(total/100) GETs against `/playlists/<id>/tracks?` — not N×.
- [ ] Manual: reload after fully loading a playlist, confirm zero network calls for that playlist's tracks.
- [ ] Manual: navigate between two playlists rapidly, confirm no duplicate loads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)