### PR TITLE
feat(playlist): sortable tables, track selection + delete, conductor.json

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,10 @@ Spotify Organiser — a React SPA that helps users clean up and organise their S
 - **Releases:** `semantic-release` on `master`. The deploy workflow runs `scripts/semver.sh` first to compute the next version, injects it as `PACKAGE_VERSION` env var into the Vite build, deploys, then runs `yarn release` to publish the GitHub release. Skipping `feat:`/`fix:` commits means no version bump and no release.
 - **Pre-push hook:** runs `yarn lint` and `yarn stylelint`. Do not bypass with `--no-verify`.
 
+## Conductor
+
+`conductor.json` defines `setup` (`corepack enable && yarn install --immutable`), `run` (`yarn dev`), and `archive` (rm `node_modules dist .firebase`). No env files to copy — Firebase/Spotify config is baked in via `package.json` env vars at build time, so new workspaces should `yarn dev` cleanly after setup.
+
 ## Gotchas
 
 - **Husky hooks need `node_modules`.** Fresh clones / worktrees must `yarn --immutable` before the first commit/push, or commit-msg/pre-push will fail with "Couldn't find the node_modules state file".

--- a/conductor.json
+++ b/conductor.json
@@ -1,0 +1,8 @@
+{
+	"scripts": {
+		"setup": "corepack enable && yarn install --immutable",
+		"run": "yarn dev",
+		"archive": "rm -rf node_modules dist .firebase"
+	},
+	"runScriptMode": "concurrent"
+}

--- a/src/components/Tracks.tsx
+++ b/src/components/Tracks.tsx
@@ -1,72 +1,193 @@
-import React, { useMemo } from 'react'
-import { Playlist, Track } from '~/types'
-import { Duration, useAppSelector } from '~/utils'
+import React, { useMemo, useState } from 'react'
+import { Actions } from '~/actions'
+import { Playlist, Sort, Track } from '~/types'
+import { canModifyPlaylist, Duration, getNextSortMode, getSortIcon, useAppDispatch, useAppSelector } from '~/utils'
+import Button from './Button'
 import { ArtistLinks, UriLink } from './UriLink'
+
+type SortKey = 'name' | 'artist' | 'album' | 'added_by' | 'added_at' | 'duration' | 'in_playlists' | 'plays'
 
 type Props = {
 	tracks: Track[]
-	currentPlaylistId?: string
+	playlist: Playlist
 }
-const Tracks: React.FC<Props> = ({ tracks, currentPlaylistId }) => {
+
+const Tracks: React.FC<Props> = ({ tracks, playlist }) => {
+	const dispatch = useAppDispatch()
 	const playlists = useAppSelector(s => s.playlists)
+	const user = useAppSelector(s => s.user)
+	const canModify = user ? canModifyPlaylist(playlist, user) : false
+
+	const [sort, setSort] = useState<{ key: SortKey; mode: Sort }>({ key: 'added_at', mode: Sort.None })
+	const [selected, setSelected] = useState<Set<string>>(new Set())
+
 	const contributors = new Set(tracks.map(t => t.meta.added_by.id))
 	const plays = tracks.reduce((a, t) => a + (t.meta.plays || 0), 0)
+	const showAddedBy = contributors.size > 1
 
 	const otherPlaylistsByTrack = useMemo(() => {
 		const map: Record<Track['id'], Playlist[]> = {}
-		const candidates = playlists.filter(pl => pl.id !== currentPlaylistId && pl.tracks.lastFetched)
+		const candidates = playlists.filter(pl => pl.id !== playlist.id && pl.tracks.lastFetched)
 		for (const track of tracks) {
 			map[track.id] = candidates.filter(pl => pl.tracks.items[track.id] !== undefined)
 		}
 		return map
-	}, [playlists, tracks, currentPlaylistId])
+	}, [playlists, tracks, playlist.id])
 
-	return tracks.length > 0 ? (
-		<table className="playlists">
-			<thead className="sticky top-0 bg-black">
-				<tr>
-					<th>Name</th>
-					<th>Artist</th>
-					<th>Album</th>
-					{contributors.size > 1 && <th>Added by</th>}
-					<th>Added at</th>
-					<th>Duration</th>
-					<th title="Number of other loaded playlists this track appears in">In playlists</th>
-					<th title={plays > 0 ? undefined : 'Plays are tracked only while "Watch skips" is enabled in settings'}>Plays</th>
-				</tr>
-			</thead>
-			<tbody>
-				{tracks.map((track, index) => {
-					const others = otherPlaylistsByTrack[track.id] || []
-					return (
-						<tr key={track.id + index}>
-							<td>
-								<UriLink object={track} />
-							</td>
-							<td>
-								<ArtistLinks artists={track.artists} />
-							</td>
-							<td>
-								<UriLink object={track.album} />
-							</td>
-							{contributors.size > 1 && (
+	const sortedTracks = useMemo(() => {
+		if (sort.mode === Sort.None) return tracks
+		const direction = sort.mode === Sort.Asc ? 1 : -1
+		const value = (t: Track): string | number => {
+			switch (sort.key) {
+				case 'name':
+					return t.name.toLocaleLowerCase()
+				case 'artist':
+					return t.artists[0]?.name.toLocaleLowerCase() ?? ''
+				case 'album':
+					return t.album.name.toLocaleLowerCase()
+				case 'added_by':
+					return getDisplayName(t.meta.added_by).toLocaleLowerCase()
+				case 'added_at':
+					return new Date(t.meta.added_at).getTime()
+				case 'duration':
+					return t.duration_ms
+				case 'in_playlists':
+					return otherPlaylistsByTrack[t.id]?.length ?? 0
+				case 'plays':
+					return t.meta.plays ?? 0
+			}
+		}
+		return tracks.slice().sort((a, b) => {
+			const va = value(a)
+			const vb = value(b)
+			if (va < vb) return -1 * direction
+			if (va > vb) return 1 * direction
+			return 0
+		})
+	}, [tracks, sort, otherPlaylistsByTrack])
+
+	const allSelected = selected.size > 0 && selected.size === tracks.length
+	const rowKey = (t: Track) => `${t.id}:${t.meta.index}`
+
+	const toggleAll = (checked: boolean) =>
+		setSelected(checked ? new Set(tracks.map(rowKey)) : new Set())
+
+	const toggleRow = (key: string, checked: boolean) => {
+		const next = new Set(selected)
+		if (checked) next.add(key)
+		else next.delete(key)
+		setSelected(next)
+	}
+
+	const onDelete = () => {
+		const uris = Array.from(
+			new Set(tracks.filter(t => selected.has(rowKey(t))).map(t => t.uri))
+		)
+		if (uris.length === 0) return
+		const confirm = window.confirm(
+			`Remove ${selected.size} track${selected.size !== 1 ? 's' : ''} from ${playlist.name}?`
+		)
+		if (!confirm) return
+		dispatch(Actions.deleteTracks(uris, { id: playlist.id, snapshot_id: playlist.snapshot_id }))
+		setSelected(new Set())
+	}
+
+	if (tracks.length === 0) return <div>No tracks.</div>
+
+	const onSort = (key: SortKey) =>
+		setSort(prev => ({ key, mode: getNextSortMode(prev.key === key, prev.mode) }))
+
+	const sortHeader = (label: string, key: SortKey, title?: string) => (
+		<th title={title}>
+			<a onClick={() => onSort(key)}>{label}</a>
+			&nbsp;{getSortIcon(sort.key === key, sort.mode)}
+		</th>
+	)
+
+	return (
+		<>
+			{canModify && (
+				<div className="flex items-center gap-2 px-2 py-1 text-sm">
+					<span className="opacity-80">
+						{selected.size > 0 ? `${selected.size} selected` : 'Select tracks to remove'}
+					</span>
+					<Button
+						icon="trash"
+						disabled={selected.size === 0}
+						onClick={onDelete}
+						title="Remove selected tracks from this playlist"
+					>
+						Delete
+					</Button>
+				</div>
+			)}
+			<table className="playlists">
+				<thead className="sticky top-0 bg-black">
+					<tr>
+						{canModify && (
+							<th className="select">
+								<input
+									type="checkbox"
+									checked={allSelected}
+									onChange={e => toggleAll(e.target.checked)}
+								/>
+							</th>
+						)}
+						{sortHeader('Name', 'name')}
+						{sortHeader('Artist', 'artist')}
+						{sortHeader('Album', 'album')}
+						{showAddedBy && sortHeader('Added by', 'added_by')}
+						{sortHeader('Added at', 'added_at')}
+						{sortHeader('Duration', 'duration')}
+						{sortHeader('In playlists', 'in_playlists', 'Number of other loaded playlists this track appears in')}
+						{sortHeader(
+							'Plays',
+							'plays',
+							plays > 0 ? undefined : 'Plays are tracked only while "Watch skips" is enabled in settings'
+						)}
+					</tr>
+				</thead>
+				<tbody>
+					{sortedTracks.map(track => {
+						const key = rowKey(track)
+						const others = otherPlaylistsByTrack[track.id] || []
+						return (
+							<tr key={key}>
+								{canModify && (
+									<td className="select">
+										<input
+											type="checkbox"
+											checked={selected.has(key)}
+											onChange={e => toggleRow(key, e.target.checked)}
+										/>
+									</td>
+								)}
 								<td>
-									<UriLink object={track.meta.added_by}>
-										{getDisplayName(track.meta.added_by)}
-									</UriLink>
+									<UriLink object={track} />
 								</td>
-							)}
-							<td>{new Date(track.meta.added_at).toLocaleDateString()}</td>
-							<td>{new Duration(track.duration_ms).toMinutesString()}</td>
-							<td title={others.map(pl => pl.name).join('\n')}>{others.length}</td>
-							<td>{track.meta.plays ?? 0}</td>
-						</tr>
-					)
-				})}
-			</tbody>
-		</table>
-	) : (
-		<div>No tracks.</div>
+								<td>
+									<ArtistLinks artists={track.artists} />
+								</td>
+								<td>
+									<UriLink object={track.album} />
+								</td>
+								{showAddedBy && (
+									<td>
+										<UriLink object={track.meta.added_by}>
+											{getDisplayName(track.meta.added_by)}
+										</UriLink>
+									</td>
+								)}
+								<td>{new Date(track.meta.added_at).toLocaleDateString()}</td>
+								<td>{new Duration(track.duration_ms).toMinutesString()}</td>
+								<td title={others.map(pl => pl.name).join('\n')}>{others.length}</td>
+								<td>{track.meta.plays ?? 0}</td>
+							</tr>
+						)
+					})}
+				</tbody>
+			</table>
+		</>
 	)
 }
 

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,14 +1,18 @@
-import React, { useMemo } from 'react'
+import React, { useMemo, useState } from 'react'
 import { useSelector } from 'react-redux'
 import { Link } from 'react-router-dom'
-import { State } from '~/types'
-import { Duration, SongCache, songEntriesToSongs, useFirebase } from '~/utils'
+import { Sort, State } from '~/types'
+import { Duration, getNextSortMode, getSortIcon, SongCache, songEntriesToSongs, useFirebase } from '~/utils'
+
+type SkipRateRow = { name: string; id: string; skipRate: number; totalSkips: number; totalPlays: number }
+type SkipSortKey = 'name' | 'skipRate' | 'totalSkips' | 'totalPlays'
 
 export const Dashboard: React.FC = () => {
 	const playlists = useSelector((s: State) => s.playlists)
 	const user = useSelector((s: State) => s.user)
 	const rawPlays = useFirebase(`users/${user?.uid}/plays/`)
 	const rawSkips = useFirebase(`users/${user?.uid}/skips/`)
+	const [skipSort, setSkipSort] = useState<{ key: SkipSortKey; mode: Sort }>({ key: 'skipRate', mode: Sort.Desc })
 
 	const stats = useMemo(() => {
 		const plays = rawPlays || {}
@@ -31,7 +35,7 @@ export const Dashboard: React.FC = () => {
 		const uniqueTracks = trackCounts.size
 
 		// Skip stats per playlist
-		const playlistSkipRates = loadedPlaylists
+		const playlistSkipRates: SkipRateRow[] = loadedPlaylists
 			.map(pl => {
 				const contextUri = pl.uri
 				const playlistSkips = skips[contextUri] || {}
@@ -42,7 +46,6 @@ export const Dashboard: React.FC = () => {
 				return { name: pl.name, id: pl.id, skipRate, totalSkips, totalPlays }
 			})
 			.filter(pl => pl.totalPlays > 0)
-			.sort((a, b) => b.skipRate - a.skipRate)
 
 		// Most skipped tracks (aggregate across all playlists)
 		const trackSkips = new Map<string, number>()
@@ -67,6 +70,43 @@ export const Dashboard: React.FC = () => {
 			mostSkipped
 		}
 	}, [playlists, rawPlays, rawSkips])
+
+	const sortedSkipRates = useMemo(() => {
+		const rows = stats.playlistSkipRates
+		if (skipSort.mode === Sort.None) return rows
+		const direction = skipSort.mode === Sort.Asc ? 1 : -1
+		const value = (r: SkipRateRow): string | number => {
+			switch (skipSort.key) {
+				case 'name':
+					return r.name.toLocaleLowerCase()
+				case 'skipRate':
+					return r.skipRate
+				case 'totalSkips':
+					return r.totalSkips
+				case 'totalPlays':
+					return r.totalPlays
+			}
+		}
+		return rows.slice().sort((a, b) => {
+			const va = value(a)
+			const vb = value(b)
+			if (va < vb) return -1 * direction
+			if (va > vb) return 1 * direction
+			return 0
+		})
+	}, [stats.playlistSkipRates, skipSort])
+
+	const onSkipSort = (key: SkipSortKey) =>
+		setSkipSort(prev => ({ key, mode: getNextSortMode(prev.key === key, prev.mode) }))
+
+	const skipHeader = (label: string, key: SkipSortKey, align: 'left' | 'right' = 'left') => (
+		<th className={align === 'right' ? 'text-right' : undefined}>
+			<a onClick={() => onSkipSort(key)} className="cursor-pointer">
+				{label}
+			</a>
+			&nbsp;{getSortIcon(skipSort.key === key, skipSort.mode)}
+		</th>
+	)
 
 	if (!user) return null
 
@@ -103,14 +143,14 @@ export const Dashboard: React.FC = () => {
 						<table className="w-full max-w-2xl">
 							<thead>
 								<tr className="text-left text-gray-400 text-sm">
-									<th>Playlist</th>
-									<th className="text-right">Skip Rate</th>
-									<th className="text-right">Skips</th>
-									<th className="text-right">Plays</th>
+									{skipHeader('Playlist', 'name')}
+									{skipHeader('Skip Rate', 'skipRate', 'right')}
+									{skipHeader('Skips', 'totalSkips', 'right')}
+									{skipHeader('Plays', 'totalPlays', 'right')}
 								</tr>
 							</thead>
 							<tbody>
-								{stats.playlistSkipRates.slice(0, 10).map(pl => (
+								{sortedSkipRates.slice(0, 10).map(pl => (
 									<tr key={pl.id}>
 										<td>
 											<Link to={`/playlists/${pl.id}`} className="hover:underline">

--- a/src/pages/PlaylistRoute.tsx
+++ b/src/pages/PlaylistRoute.tsx
@@ -56,7 +56,7 @@ const PlaylistRoute: React.FC = () => {
 				</Link>
 			</div>
 			<hr />
-			<Tracks tracks={tracks} currentPlaylistId={playlist.id} />
+			<Tracks tracks={tracks} playlist={playlist} />
 		</div>
 	)
 }

--- a/src/pages/Search.tsx
+++ b/src/pages/Search.tsx
@@ -1,15 +1,18 @@
 import React, { useMemo, useState } from 'react'
 import { useSelector } from 'react-redux'
 import { ArtistLinks, UriLink } from '~/components/UriLink'
-import { State, Track } from '~/types'
-import { Duration, SongCache } from '~/utils'
+import { Sort, State, Track } from '~/types'
+import { Duration, getNextSortMode, getSortIcon, SongCache } from '~/utils'
 
 type SearchResult = Track & {
 	playlistNames: string[]
 }
 
+type SortKey = 'name' | 'artist' | 'album' | 'duration' | 'in_playlists'
+
 export const Search: React.FC = () => {
 	const [query, setQuery] = useState('')
+	const [sort, setSort] = useState<{ key: SortKey; mode: Sort }>({ key: 'name', mode: Sort.None })
 	const playlists = useSelector((s: State) => s.playlists)
 
 	const results = useMemo(() => {
@@ -36,6 +39,42 @@ export const Search: React.FC = () => {
 
 		return matches
 	}, [query, playlists])
+
+	const sortedResults = useMemo(() => {
+		if (sort.mode === Sort.None) return results
+		const direction = sort.mode === Sort.Asc ? 1 : -1
+		const value = (r: SearchResult): string | number => {
+			switch (sort.key) {
+				case 'name':
+					return r.name.toLocaleLowerCase()
+				case 'artist':
+					return r.artists[0]?.name.toLocaleLowerCase() ?? ''
+				case 'album':
+					return r.album.name.toLocaleLowerCase()
+				case 'duration':
+					return r.duration_ms
+				case 'in_playlists':
+					return r.playlistNames.length
+			}
+		}
+		return results.slice().sort((a, b) => {
+			const va = value(a)
+			const vb = value(b)
+			if (va < vb) return -1 * direction
+			if (va > vb) return 1 * direction
+			return 0
+		})
+	}, [results, sort])
+
+	const onSort = (key: SortKey) =>
+		setSort(prev => ({ key, mode: getNextSortMode(prev.key === key, prev.mode) }))
+
+	const sortHeader = (label: string, key: SortKey) => (
+		<th>
+			<a onClick={() => onSort(key)}>{label}</a>
+			&nbsp;{getSortIcon(sort.key === key, sort.mode)}
+		</th>
+	)
 
 	return (
 		<div className="max-h-full grid grid-rows-[auto,1fr] grid-cols-1">
@@ -71,15 +110,15 @@ export const Search: React.FC = () => {
 					<table className="playlists w-full">
 						<thead className="sticky top-0 bg-black">
 							<tr>
-								<th>Name</th>
-								<th>Artist</th>
-								<th>Album</th>
-								<th>Duration</th>
-								<th>In Playlists</th>
+								{sortHeader('Name', 'name')}
+								{sortHeader('Artist', 'artist')}
+								{sortHeader('Album', 'album')}
+								{sortHeader('Duration', 'duration')}
+								{sortHeader('In Playlists', 'in_playlists')}
 							</tr>
 						</thead>
 						<tbody>
-							{results.map((track, index) => (
+							{sortedResults.map((track, index) => (
 								<tr key={track.id + index}>
 									<td>
 										<UriLink object={track} />


### PR DESCRIPTION
## Summary
- Tracks (playlist page), Search, and Dashboard "Highest Skip Rates" tables now sort on every column (tri-state cycle, same `getNextSortMode`/`getSortIcon` helpers as the Playlists table)
- Playlist page lets owners select tracks via checkboxes + "select all" and delete them via the existing `Actions.deleteTracks` saga (passes `snapshot_id`); controls are hidden on playlists the user can't modify
- Adds `conductor.json` so new Conductor workspaces auto-run `corepack enable && yarn install --immutable` then `yarn dev`

Skips pages were left alone — they're nested lists, not tables, and would need a different UI (filed mentally as a follow-up if desired).

## Test plan
- [ ] Open a playlist on the live preview; click each column header — order toggles None → Desc → Asc
- [ ] As playlist owner, tick a few tracks (and "select all"); Delete prompts to confirm, removes them, tracks refetch
- [ ] As a non-owner (e.g. a Spotify-editorial playlist), checkboxes / Delete bar do not appear
- [ ] `/search` results table sorts on all columns
- [ ] Dashboard "Highest Skip Rates" sorts on all columns (default Skip Rate Desc preserved)
- [ ] In a fresh Conductor workspace, `setup` then `run` boots `yarn dev` on :1337 cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)