### PR TITLE
style(table): prevent table headers from wrapping

### DIFF
--- a/src/styles/components/table.scss
+++ b/src/styles/components/table.scss
@@ -11,6 +11,10 @@ table {
 		border: none;
 	}
 
+	th {
+		white-space: nowrap;
+	}
+
 	td {
 		line-height: 1.2;
 	}


### PR DESCRIPTION
## Summary
- Add `white-space: nowrap` to `th` in the shared table styles so column headers stay on a single line across Playlists, Tracks, Dashboard, Search, and EmbeddedPlaylist.

## Test plan
- [ ] Visually verify table headers on Dashboard, Playlists, Tracks, Search, and embedded playlist views do not wrap at narrow widths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)