### PR TITLE
fix(auth): auto-recover stale Spotify sessions via silent re-auth

### DIFF
--- a/__tests__/utils/spotifyAuth.test.ts
+++ b/__tests__/utils/spotifyAuth.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { finishReauth, reauthenticate, reauthInProgress, RefreshTokenRejected, refreshAccessToken } from '~/utils/spotifyAuth'
+
+const TOKEN_ENDPOINT = 'https://accounts.spotify.com/api/token'
+
+const tokenBody = {
+	access_token: 'new-access',
+	refresh_token: 'new-refresh',
+	expires_in: 3600,
+	token_type: 'Bearer',
+	scope: ''
+}
+
+function jsonResponse (status: number, body: unknown): Response {
+	return {
+		ok: status >= 200 && status < 300,
+		status,
+		json: async () => body,
+		text: async () => JSON.stringify(body)
+	} as Response
+}
+
+describe('refreshAccessToken', () => {
+	beforeEach(() => {
+		vi.useFakeTimers()
+	})
+
+	afterEach(() => {
+		vi.useRealTimers()
+		vi.restoreAllMocks()
+	})
+
+	it('returns the token response on success', async () => {
+		const fetchMock = vi.fn().mockResolvedValue(jsonResponse(200, tokenBody))
+		vi.stubGlobal('fetch', fetchMock)
+
+		await expect(refreshAccessToken('refresh')).resolves.toEqual(tokenBody)
+		expect(fetchMock).toHaveBeenCalledOnce()
+		expect(fetchMock.mock.calls[0][0]).toBe(TOKEN_ENDPOINT)
+	})
+
+	it('retries transient 5xx responses and succeeds', async () => {
+		const fetchMock = vi
+			.fn()
+			.mockResolvedValueOnce(jsonResponse(500, { error: 'server_error', error_description: 'Failed to remove token' }))
+			.mockResolvedValueOnce(jsonResponse(200, tokenBody))
+		vi.stubGlobal('fetch', fetchMock)
+
+		const promise = refreshAccessToken('refresh')
+		await vi.runAllTimersAsync()
+
+		await expect(promise).resolves.toEqual(tokenBody)
+		expect(fetchMock).toHaveBeenCalledTimes(2)
+	})
+
+	it('gives up after repeated 5xx and throws a transient Error (not RefreshTokenRejected)', async () => {
+		const fetchMock = vi
+			.fn()
+			.mockResolvedValue(jsonResponse(500, { error: 'server_error', error_description: 'Failed to remove token' }))
+		vi.stubGlobal('fetch', fetchMock)
+
+		const promise = refreshAccessToken('refresh')
+		const caught = promise.catch((e: unknown) => e)
+		await vi.runAllTimersAsync()
+		const error = await caught
+
+		expect(error).toBeInstanceOf(Error)
+		expect(error).not.toBeInstanceOf(RefreshTokenRejected)
+		expect((error as Error).message).toContain('500')
+		expect(fetchMock.mock.calls.length).toBe(3)
+	})
+
+	it('does not retry 4xx and throws RefreshTokenRejected immediately', async () => {
+		const fetchMock = vi.fn().mockResolvedValue(jsonResponse(400, { error: 'invalid_grant' }))
+		vi.stubGlobal('fetch', fetchMock)
+
+		await expect(refreshAccessToken('refresh')).rejects.toBeInstanceOf(RefreshTokenRejected)
+		expect(fetchMock).toHaveBeenCalledOnce()
+	})
+})
+
+describe('silent re-auth', () => {
+	let originalLocation: Location
+
+	beforeEach(() => {
+		sessionStorage.clear()
+		originalLocation = window.location
+		delete (window as { location?: Location }).location
+		;(window as { location: unknown }).location = { href: '', pathname: '/skips' }
+	})
+
+	afterEach(() => {
+		;(window as { location: Location }).location = originalLocation
+		sessionStorage.clear()
+	})
+
+	it('flags the bounce and redirects through the authorize endpoint', async () => {
+		expect(reauthInProgress()).toBe(false)
+
+		await reauthenticate()
+
+		expect(reauthInProgress()).toBe(true)
+		expect(window.location.href).toContain('accounts.spotify.com/authorize')
+		expect(window.location.href).toContain('response_type=code')
+		// the user's current path rides along so they land back where they were
+		expect(window.location.href).toContain('state=%2Fskips')
+	})
+
+	it('finishReauth clears the in-progress flag', () => {
+		sessionStorage.setItem('spotify_reauth_in_progress', '123')
+		expect(reauthInProgress()).toBe(true)
+
+		finishReauth()
+
+		expect(reauthInProgress()).toBe(false)
+	})
+})

--- a/src/components/layout/Auth.tsx
+++ b/src/components/layout/Auth.tsx
@@ -1,9 +1,7 @@
 import React from 'react'
 import { connect } from 'react-redux'
 import { replace } from 'redux-first-history'
-import { Actions } from '~/actions'
 import { State } from '~/types'
-import { parseQueryString } from '~/utils/parseQueryString'
 import { loginLink } from '~/utils/spotifyAuth'
 
 const mapStateToProps = (state: State) => ({
@@ -11,21 +9,12 @@ const mapStateToProps = (state: State) => ({
 })
 
 const dispatchToProps = {
-	codeReceived: Actions.codeReceived,
 	replace
 }
 
 type Props = ReturnType<typeof mapStateToProps> & typeof dispatchToProps
 
 class Login extends React.Component<Props> {
-	componentDidMount () {
-		if (location.search.includes('code=')) {
-			const query = parseQueryString(location.href, false)
-			this.props.codeReceived(query.code, query.state || null)
-			history.replaceState({}, '', location.pathname)
-		}
-	}
-
 	componentDidUpdate () {
 		if (this.props.user) this.props.replace('/')
 	}

--- a/src/sagas/login.ts
+++ b/src/sagas/login.ts
@@ -2,7 +2,17 @@ import { replace } from 'redux-first-history'
 import { call, fork, put, takeLatest } from 'typed-redux-saga'
 import { Action, Actions } from '~/actions'
 import { ensureFirebaseReady, migrateLegacyUidData, resetFirebaseAuth, setSpotifyId } from '~/utils/firebase'
-import { clearTokens, exchangeCodeForToken, refreshAccessToken, storeTokens } from '~/utils/spotifyAuth'
+import { parseQueryString } from '~/utils/parseQueryString'
+import {
+	clearTokens,
+	exchangeCodeForToken,
+	finishReauth,
+	reauthenticate,
+	reauthInProgress,
+	refreshAccessToken,
+	RefreshTokenRejected,
+	storeTokens
+} from '~/utils/spotifyAuth'
 import { spotifyFetch } from './spotifyFetch'
 
 export function* loginSaga () {
@@ -17,6 +27,7 @@ function* exchangeCode (action: Action<typeof Actions.codeReceived.type>) {
 	try {
 		const tokens = yield* call(exchangeCodeForToken, action.payload)
 		storeTokens(tokens)
+		finishReauth()
 		yield* put(Actions.tokenAquired(tokens.access_token, action.meta))
 	} catch (e) {
 		console.error(`${exchangeCode.name}:`, e)
@@ -76,6 +87,17 @@ function* firebaseAuthBackground (spotifyId: string) {
 }
 
 function* loadUser (_: Action<typeof Actions.loadUser.type>) {
+	// A `?code=` in the URL means we've just come back from Spotify's authorize
+	// endpoint (either a manual login or a silent re-auth bounce). Handle it here
+	// at bootstrap so it works regardless of which view is mounted — a stale
+	// persisted user can otherwise keep <Auth> from ever rendering.
+	if (location.search.includes('code=')) {
+		const query = parseQueryString(location.href, false)
+		history.replaceState({}, '', location.pathname)
+		yield* put(Actions.codeReceived(query.code, query.state || null))
+		return
+	}
+
 	const token = localStorage.getItem('token')
 	const refreshToken = localStorage.getItem('refresh_token')
 
@@ -92,7 +114,17 @@ function* loadUser (_: Action<typeof Actions.loadUser.type>) {
 			return
 		} catch (e) {
 			console.warn('Failed to refresh token on load:', e)
-			clearTokens()
+			// Transient errors (network, Spotify 5xx) keep the token so a later
+			// load retries. A real rejection means the refresh token is dead —
+			// try a silent re-auth bounce before giving up on the session.
+			if (e instanceof RefreshTokenRejected) {
+				if (reauthInProgress()) {
+					clearTokens()
+				} else {
+					yield* call(reauthenticate) // navigates away
+					return
+				}
+			}
 		}
 	}
 	yield* put(Actions.authCheckDone())

--- a/src/sagas/spotifyFetch.ts
+++ b/src/sagas/spotifyFetch.ts
@@ -3,7 +3,7 @@ import { call, put, select } from 'typed-redux-saga'
 import { Actions } from '~/actions'
 import { State } from '~/types'
 import { sleep } from '~/utils'
-import { refreshAccessToken, RefreshTokenRejected, storeTokens } from '~/utils/spotifyAuth'
+import { reauthenticate, reauthInProgress, refreshAccessToken, RefreshTokenRejected, storeTokens } from '~/utils/spotifyAuth'
 
 // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-constraint
 export function* spotifyFetch<T extends unknown> (
@@ -44,11 +44,20 @@ export function* spotifyFetch<T extends unknown> (
 					return next as T | null
 				} catch (e) {
 					console.error('Token refresh failed:', e)
-					// Only nuke session when Spotify actually rejected the refresh
-					// token. Transient network errors (offline, DNS, etc.) should
-					// surface as a fetch failure — the next call can retry.
+					// Only act on a real rejection. Transient errors (offline, DNS,
+					// Spotify 5xx) surface as a fetch failure — the next call retries.
 					if (e instanceof RefreshTokenRejected) {
-						yield* put(Actions.logout())
+						// The refresh token is dead. Rather than dumping the user at a
+						// login button, bounce through Spotify's authorize endpoint —
+						// it redirects straight back with a fresh code when their
+						// Spotify session is alive (no consent screen). Guard against
+						// loops: if a bounce is already underway, log out for real.
+						if (reauthInProgress()) {
+							yield* put(Actions.logout())
+						} else {
+							yield* call(reauthenticate) // navigates away
+							return null
+						}
 					}
 					throw e instanceof Error ? e : new Error(String(e))
 				}

--- a/src/utils/spotifyAuth.ts
+++ b/src/utils/spotifyAuth.ts
@@ -1,9 +1,11 @@
 import { CLIENT_ID, REDIRECT_URI } from '~/consts'
 import { Scopes } from '~/types'
+import { sleep } from '~/utils/sleep'
 
 const TOKEN_ENDPOINT = 'https://accounts.spotify.com/api/token'
 const AUTHORIZE_ENDPOINT = 'https://accounts.spotify.com/authorize'
 const VERIFIER_KEY = 'spotify_pkce_verifier'
+const REAUTH_KEY = 'spotify_reauth_in_progress'
 
 const scopes = [
 	Scopes.PLAYLIST_READ_PRIVATE,
@@ -60,6 +62,30 @@ export async function loginLink (): Promise<string> {
 	return `${AUTHORIZE_ENDPOINT}?${params}`
 }
 
+/**
+ * Silently re-authenticate by bouncing through Spotify's authorize endpoint.
+ * When the user's Spotify session is still alive (the common case for an app
+ * that's already been granted access) this redirects straight back to us with a
+ * fresh `?code=` — no consent screen, no visible login page — so a dead refresh
+ * token can be recovered without the user clicking anything.
+ *
+ * Guarded against redirect loops: callers MUST check {@link reauthInProgress}
+ * first and fall back to a normal logout if a bounce is already underway. The
+ * flag is cleared by {@link finishReauth} once a code exchange succeeds.
+ */
+export async function reauthenticate (): Promise<void> {
+	sessionStorage.setItem(REAUTH_KEY, String(Date.now()))
+	window.location.href = await loginLink()
+}
+
+export function reauthInProgress (): boolean {
+	return sessionStorage.getItem(REAUTH_KEY) != null
+}
+
+export function finishReauth (): void {
+	sessionStorage.removeItem(REAUTH_KEY)
+}
+
 export async function exchangeCodeForToken (code: string): Promise<TokenResponse> {
 	const verifier = sessionStorage.getItem(VERIFIER_KEY)
 	if (!verifier) throw new Error('Missing PKCE verifier — restart login')
@@ -83,11 +109,20 @@ export async function exchangeCodeForToken (code: string): Promise<TokenResponse
 	return res.json()
 }
 
+/**
+ * Spotify definitively rejected the refresh token — the session is dead and
+ * callers should log out. Only thrown for 4xx responses; 5xx server hiccups
+ * (see {@link refreshAccessToken}) are retried and ultimately surface as a
+ * plain `Error` so callers treat them as transient and keep the session.
+ */
 export class RefreshTokenRejected extends Error {
 	constructor (public status: number, body: string) {
 		super(`Refresh token rejected (${status}): ${body}`)
 	}
 }
+
+const REFRESH_RETRIES = 3
+const REFRESH_BACKOFF_MS = 500
 
 export async function refreshAccessToken (refreshToken: string): Promise<TokenResponse> {
 	const body = new URLSearchParams({
@@ -96,16 +131,24 @@ export async function refreshAccessToken (refreshToken: string): Promise<TokenRe
 		client_id: CLIENT_ID
 	})
 
-	// Network errors (fetch rejects) bubble as-is; HTTP errors map to
-	// RefreshTokenRejected so callers can distinguish "Spotify said no" from
-	// "we couldn't reach Spotify".
-	const res = await fetch(TOKEN_ENDPOINT, {
-		method: 'POST',
-		headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-		body
-	})
-	if (!res.ok) throw new RefreshTokenRejected(res.status, await res.text())
-	return res.json()
+	// Network errors (fetch rejects) bubble as-is — the next call can retry.
+	// 4xx → RefreshTokenRejected (token is dead, callers should log out).
+	// 5xx → retry with backoff; Spotify's token endpoint flakes intermittently
+	//   (`500 {"error":"server_error","error_description":"Failed to remove token"}`).
+	//   If it keeps failing we throw a plain Error: transient, NOT a logout.
+	for (let attempt = 0; ; attempt++) {
+		const res = await fetch(TOKEN_ENDPOINT, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+			body
+		})
+		if (res.ok) return res.json()
+
+		const text = await res.text()
+		if (res.status < 500) throw new RefreshTokenRejected(res.status, text)
+		if (attempt >= REFRESH_RETRIES - 1) throw new Error(`Spotify token endpoint error (${res.status}): ${text}`)
+		await sleep(REFRESH_BACKOFF_MS * 2 ** attempt)
+	}
 }
 
 export function storeTokens (tokens: TokenResponse) {


### PR DESCRIPTION
## Problem

Coming back to the app after a long idle, the access token is expired **and** the refresh token gets rejected — sometimes a clean 400, sometimes alongside Spotify's intermittent `500 {"error":"server_error","error_description":"Failed to remove token"}`. The app would `logout()` and drop you at a "Log in to Spotify" button.

Clicking that button just bounces you through Spotify's `/authorize` endpoint and immediately back with a fresh `?code=` — **no consent screen**, because the app is already authorized. So the "fix" the user was doing by hand is something the app can do silently.

## Changes

- **Silent re-auth** (`spotifyAuth.ts`, `sagas/spotifyFetch.ts`, `sagas/login.ts`): on a real `RefreshTokenRejected`, call `reauthenticate()` — redirect through `/authorize` carrying the current path in `state` so the user lands back where they were. A `spotify_reauth_in_progress` session flag + loop guard fall back to a real logout if a bounce is already underway; `finishReauth()` clears it on a successful code exchange.
- **5xx handling** (`spotifyAuth.ts`): `refreshAccessToken` now retries transient 5xx responses with backoff (3 attempts). Only 4xx maps to `RefreshTokenRejected`; persistent 5xx surfaces as a plain `Error` treated as transient — the session is kept and the next call retries.
- **`?code=` handling moved into the `loadUser` saga** (`sagas/login.ts`, removed from `Auth.tsx`): after a silent re-auth the persisted user rehydrates, so `<App>` renders `<Routes>` and `<Auth>` never mounts — the returning code would be lost. `loadUser` runs on every bootstrap, so handling it there is robust regardless of what's rendered.

## Net effect

Idle → return → expired token → refresh fails → app silently bounces through Spotify and back → fresh tokens → you're in, on the page you were on. No button, no consent screen, no error toast. If the Spotify session itself has expired you get Spotify's normal login page (expected); the loop guard prevents redirect cycling.

## Testing

- `__tests__/utils/spotifyAuth.test.ts` (new): `refreshAccessToken` success / 5xx retry→success / 5xx exhausted→transient Error / 4xx→immediate `RefreshTokenRejected`; `reauthenticate()` flags + redirects to `/authorize?...response_type=code...state=...`; `finishReauth()` clears the flag.
- `yarn test` 38/38 · `yarn lint` clean · `yarn stylelint` clean · `yarn prod` builds.
- Note: a pre-existing `tsc --noEmit` error in `src/sagas/tracks.ts:88` exists on `master` too — unrelated, untouched, not run by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)