### PR TITLE
fix(auth): visible login feedback + silent-failure recovery

### DIFF
--- a/src/components/layout/App.tsx
+++ b/src/components/layout/App.tsx
@@ -40,7 +40,9 @@ const App: React.FC = () => {
 							<Route path="*" element={<NotFound />} />
 						</Routes>
 					) : authChecking ? (
-						<Loading />
+						<Loading>
+							<span className="mt-2 text-gray-300">Authenticating with Spotify…</span>
+						</Loading>
 					) : (
 						<Auth />
 					)}

--- a/src/components/layout/Auth.tsx
+++ b/src/components/layout/Auth.tsx
@@ -1,38 +1,92 @@
-import React from 'react'
-import { connect } from 'react-redux'
+import { type FC, useEffect, useRef, useState } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
 import { replace } from 'redux-first-history'
+import { Actions } from '~/actions'
 import type { State } from '~/types'
 import { loginLink } from '~/utils/spotifyAuth'
 
-const mapStateToProps = (state: State) => ({
-	user: state.user
-})
+type Status = 'idle' | 'pending' | 'failed'
 
-const dispatchToProps = {
-	replace
-}
+// Browsers don't fire an event when an in-tab navigation actually commits, so
+// we use a wall-clock guard: if `window.location` is assigned but the page
+// doesn't navigate within this window, surface a retry. Covers Safari PWA
+// energy-reload zombie tabs, blocked `sessionStorage`, popup blockers on the
+// OAuth host, and other silent failure modes that previously left the user
+// staring at a dead button.
+const REDIRECT_TIMEOUT_MS = 3000
 
-type Props = ReturnType<typeof mapStateToProps> & typeof dispatchToProps
+const Auth: FC = () => {
+	const user = useSelector((s: State) => s.user)
+	const dispatch = useDispatch()
+	const [status, setStatus] = useState<Status>('idle')
+	const timeoutRef = useRef<number | null>(null)
 
-class Login extends React.Component<Props> {
-	componentDidUpdate() {
-		if (this.props.user) this.props.replace('/')
-	}
+	useEffect(() => {
+		if (user) dispatch(replace('/'))
+	}, [user, dispatch])
 
-	handleLogin = async (e: React.MouseEvent) => {
+	useEffect(
+		() => () => {
+			if (timeoutRef.current) clearTimeout(timeoutRef.current)
+		},
+		[]
+	)
+
+	const handleLogin = async (e: React.MouseEvent) => {
 		e.preventDefault()
-		window.location.href = await loginLink()
+		if (timeoutRef.current) clearTimeout(timeoutRef.current)
+		setStatus('pending')
+		timeoutRef.current = window.setTimeout(() => {
+			timeoutRef.current = null
+			setStatus('failed')
+			dispatch(
+				Actions.createNotification({
+					message: "Spotify didn't open — your browser may have blocked the redirect",
+					type: 'warning'
+				})
+			)
+		}, REDIRECT_TIMEOUT_MS)
+
+		try {
+			window.location.href = await loginLink()
+		} catch (err) {
+			if (timeoutRef.current) {
+				clearTimeout(timeoutRef.current)
+				timeoutRef.current = null
+			}
+			setStatus('failed')
+			dispatch(
+				Actions.createNotification({
+					message: `Login didn't start: ${(err as Error).message}`,
+					type: 'warning'
+				})
+			)
+		}
 	}
 
-	render() {
-		return (
-			<div className="auth">
-				<a className="button primary" href="#" onClick={this.handleLogin}>
-					Log in to Spotify
-				</a>
-			</div>
-		)
-	}
+	const label =
+		status === 'pending'
+			? 'Connecting to Spotify…'
+			: status === 'failed'
+				? "Couldn't reach Spotify · Retry"
+				: 'Log in to Spotify'
+
+	const variant = status === 'pending' ? 'pending' : status === 'failed' ? 'failed' : 'primary'
+
+	return (
+		<div className="auth">
+			<a
+				className={`button ${variant}`}
+				href="#"
+				onClick={handleLogin}
+				aria-busy={status === 'pending'}
+				aria-live="polite"
+			>
+				{status === 'pending' && <i className="fa fa-spinner fa-spin mr-2" />}
+				{label}
+			</a>
+		</div>
+	)
 }
 
-export default connect(mapStateToProps, dispatchToProps)(Login)
+export default Auth

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -3,6 +3,7 @@ import type React from 'react'
 import { Link, NavLink } from 'react-router-dom'
 import type { User } from '~/types'
 import { UriLink } from '../UriLink'
+import { IndexingStatus } from './IndexingStatus'
 
 type Props = {
 	user: User | null // TODO
@@ -36,7 +37,8 @@ export const Header: React.FC<Props> = ({ user }) => (
 							<NavLink to="/skips">Skipped songs</NavLink>
 						</li>
 					</ul>
-					<ul className="justify-self-end">
+					<ul className="justify-self-end flex items-center gap-4">
+						<IndexingStatus />
 						<li>
 							<UriLink object={user.spotify}>
 								<img

--- a/src/components/layout/IndexingStatus.tsx
+++ b/src/components/layout/IndexingStatus.tsx
@@ -1,0 +1,36 @@
+import type { FC } from 'react'
+import { useSelector } from 'react-redux'
+import type { State } from '~/types'
+
+// Aggregate "is the library still being indexed?" pill for the header.
+//
+// The per-row floppy icon on Playlists already signals which individual
+// playlists are cached locally — this is the totals view, so the user can tell
+// at a glance whether the background `getAllTracks` cascade is still running
+// without scanning the list.
+//
+// The amber colour matches `$progress` in variables.scss — same "working on
+// it" hue used by the login button's pending state, so the visual language is
+// consistent across stages of the journey.
+export const IndexingStatus: FC = () => {
+	const { indexed, total } = useSelector((s: State) => ({
+		indexed: s.playlists.filter(p => p.tracks.lastFetched != null).length,
+		total: s.playlists.length
+	}))
+
+	if (total === 0 || indexed >= total) return null
+
+	return (
+		<li
+			className="flex items-center gap-1.5 text-sm"
+			style={{ color: '#f5a623' }}
+			title={`${indexed} of ${total} playlists cached locally`}
+			aria-live="polite"
+		>
+			<i className="fa fa-spinner fa-spin" aria-hidden="true" />
+			<span>
+				Indexing {indexed}/{total}
+			</span>
+		</li>
+	)
+}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -4,6 +4,7 @@ import { connect, useSelector } from 'react-redux'
 import { Actions } from '~/actions'
 import Button from '~/components/Button'
 import Input from '~/components/Input'
+import Loading from '~/components/Loading'
 import Modal from '~/components/Modal'
 import Playlists from '~/components/Playlists'
 import PullPlaylist from '~/components/PullPlaylist'
@@ -60,6 +61,17 @@ const PlaylistsManager: React.FC = () => {
 	)
 
 	if (!user) return null
+
+	// Bridges the gap between `authCheckDone` and the first `playlistsFetched`
+	// — for a large library `me/playlists` takes ~10s, which previously showed
+	// an empty manager screen with no signal that anything was loading.
+	if (allPlaylists.length === 0) {
+		return (
+			<Loading>
+				<span className="mt-2 text-gray-300">Fetching your library…</span>
+			</Loading>
+		)
+	}
 
 	const error = getDeduplicateErrors(mode, selectedPlaylists, secondPlaylist, user)
 

--- a/src/styles/input/button.scss
+++ b/src/styles/input/button.scss
@@ -47,4 +47,27 @@ a.button:hover {
 			background-color: #555;
 		}
 	}
+
+	&.pending {
+		border: none;
+		background-color: $progress;
+		cursor: wait;
+
+		&:hover:not(:active) {
+			background-color: $progress;
+			padding: 0.5rem;
+			border-width: 0;
+		}
+	}
+
+	&.failed {
+		background-color: transparent;
+		border-color: $progress;
+		color: $progress;
+
+		&:hover:not(:active) {
+			background-color: rgba($progress, 0.08);
+			border-color: $progress;
+		}
+	}
 }

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -16,6 +16,12 @@ $primary-dark: #14833b;
 $primary: #1db954;
 $primary-light: #1ed760;
 
+// In-flight / amber. VU-meter colour, used for "working on it" states (login
+// pending, library indexing chip) so a single hue means the same thing across
+// the app.
+$progress: #f5a623;
+$progress-dark: #cc8a1c;
+
 @mixin tablet {
 	@media (max-width: $max-width) {
 		@content;


### PR DESCRIPTION
## Summary

- Login button silently no-opped when `loginLink()` rejected or `window.location.href` didn't actually navigate (Safari PWA zombie tabs, blocked `sessionStorage`, popup blockers). Now a 3-state button (idle / pending / failed) with a 3-second wall-clock timeout that flips to a retry-able failed state and surfaces the cause via the existing notification channel.
- Header carries an amber "Indexing N/M" chip while the background `getAllTracks` cascade runs (auto-hides at completion), so a multi-minute background load on big libraries doesn't look like nothing is happening.
- Auth-checking and library-fetching Loading views now name what they're doing ("Authenticating with Spotify…", "Fetching your library…") instead of an unlabelled spinner.

Same amber (`$progress: #f5a623`) threads through every "working on it" surface — login pending, the indexing chip — so one colour means one thing across the journey.

## Test plan

- [ ] Cold login: click "Log in to Spotify", verify pill flips to amber "Connecting to Spotify…" before bouncing to Spotify.
- [ ] Silent-failure simulation: in DevTools, run `crypto.subtle.digest = () => new Promise(() => {})`, click the button — within ~3s the pill becomes "Couldn't reach Spotify · Retry" and a yellow toast appears. Clicking retries.
- [ ] After login, while playlists are still indexing, confirm the amber "Indexing N/M" chip appears in the header next to the avatar. Wait for completion — the chip disappears.
- [ ] During the brief gap between auth-check-done and `playlistsFetched`, the centred loader reads "Fetching your library…".

🤖 Generated with [Claude Code](https://claude.com/claude-code)