### PR TITLE
fix(playlists): hydrate PlaylistCache before publishing list

### DIFF
--- a/src/sagas/playlists.ts
+++ b/src/sagas/playlists.ts
@@ -1,7 +1,7 @@
 import { all, call, put, select, takeEvery, takeLatest } from 'typed-redux-saga'
 import { type Action, Actions } from '~/actions'
 import type { Playlist, State, Track } from '~/types'
-import { deduplicate, partition, pullTracks, songEntriesToSongs } from '~/utils'
+import { deduplicate, PlaylistCache, partition, pullTracks, songEntriesToSongs } from '~/utils'
 import { spotifyFetch } from './spotifyFetch'
 import { getTracks } from './tracks'
 
@@ -27,6 +27,12 @@ function* getPlaylists() {
 		}
 		offset += limit
 	} while (response.next !== null)
+	// The FETCH_PLAYLISTS_SUCCESS reducer reads PlaylistCache synchronously to
+	// seed each playlist's items + lastFetched. If the API races ahead of cache
+	// hydration the reducer sees an empty Map and leaves redux with no items —
+	// the "In playlists" column then renders 0 for every track because the
+	// `tracks.lastFetched` filter excludes every other playlist.
+	yield* call(() => PlaylistCache.ready)
 	yield* put(Actions.playlistsFetched(playlists))
 }
 


### PR DESCRIPTION
## Summary

- The 'In playlists' count was rendering 0 for every track on both the playlist tracks view and the track detail page, even for tracks known to be in multiple playlists.
- Root cause: a race between async `PlaylistCache` hydration (localforage) and the synchronous `FETCH_PLAYLISTS_SUCCESS` reducer. If `/me/playlists` resolves before the cache Map is populated, the reducer sees an empty Map, falls back to empty state, and seeds redux with `{ items: {}, lastFetched: null }` for every cached playlist. `getAllTracks` then matches `snapshot_id` + `lastFetched` on the cache entry and skips dispatching `FETCH_TRACKS_SUCCESS`, leaving redux permanently stale. The `pl.tracks.lastFetched` filter in `Tracks.tsx` / `TrackRoute.tsx` excludes every other playlist → count is always 0.
- Fix: `await PlaylistCache.ready` after the pagination loop in `getPlaylists`, right before dispatching `playlistsFetched`. API fetch still runs concurrently with hydration; only blocks if hydration is slower.

## Test plan

- [ ] Cold reload the deployed PWA with a populated cache; verify the 'In playlists' column on the playlist tracks view shows non-zero counts for tracks that exist in multiple playlists.
- [ ] Navigate to a track detail page; verify the 'In playlists' section lists every playlist containing that track.
- [ ] Confirm initial cold load (no cache yet) still works — playlists fetch then load tracks normally.
- [ ] `yarn test` passes (43/43 local).
- [ ] `yarn lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)