### PR TITLE
fix(playlists): chunk bulk track deletes to Spotify's 100-uri cap

### DIFF
--- a/src/sagas/playlists.ts
+++ b/src/sagas/playlists.ts
@@ -39,17 +39,20 @@ function* getPlaylists() {
 function* deleteTracks(action: Action<'PLAYLIST_DELETE_TRACKS'>) {
 	const { payload, meta } = action
 	const id = typeof meta === 'string' ? meta : meta.id
-	const body = {
-		tracks: payload.map(uri => ({ uri })),
-		snapshot_id: typeof meta !== 'string' ? meta.snapshot_id : undefined
-	}
+	const snapshot_id = typeof meta !== 'string' ? meta.snapshot_id : undefined
 	try {
-		yield* call(spotifyFetch, `playlists/${id}/tracks`, {
-			method: 'DELETE',
-			body: JSON.stringify(body)
-		})
+		// Spotify caps `playlists/{id}/tracks` DELETE at 100 URIs per request.
+		for (const chunk of partition([...payload], 100)) {
+			yield* call(spotifyFetch, `playlists/${id}/tracks`, {
+				method: 'DELETE',
+				body: JSON.stringify({
+					tracks: chunk.map(uri => ({ uri })),
+					snapshot_id
+				})
+			})
+		}
 		yield* put(Actions.fetchTracks(id))
-		yield* put(Actions.createNotification({ message: `${action.payload.length} tracks removed` }))
+		yield* put(Actions.createNotification({ message: `${payload.length} tracks removed` }))
 	} catch (e) {
 		yield* put(Actions.createNotification({ message: (e as Error).message, type: 'error' }))
 	}


### PR DESCRIPTION
## Summary
- `deleteTracks` saga sent every selected URI in one DELETE call to `playlists/{id}/tracks`. Spotify caps that endpoint at 100 URIs per request, so removing more than 100 tracks at once failed with "Too many ids requested".
- Chunk the payload through the existing `partition(_, 100)` util — same approach `deduplicatePlaylists` already uses on the same endpoint. One success notification fires once all chunks are deleted.

## Why now
The shift-click range-select shipped in #92 makes it easy to select hundreds of tracks at once, so this limit started getting hit in normal use.

## Test plan
- [ ] Open a playlist with >100 tracks, shift-click to select ~250 of them, hit delete → all selected tracks are removed without error, single "N tracks removed" notification
- [ ] Bulk-delete fewer than 100 tracks → still works as before (single batch)
- [ ] Bulk-delete exactly 100 → single batch
- [ ] Single-track delete from Skips pages (`ByPlaylist` / `ByTrack`) → still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)