### PR TITLE
feat(diagnostics): in-PWA diagnostics log reachable at /debug

### DIFF
--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { connect } from 'react-redux'
+import { Link } from 'react-router-dom'
 import { Actions } from '~/actions'
 import type { State } from '~/types'
 
@@ -39,6 +40,11 @@ class Settings extends React.Component<Props> {
 						/>{' '}
 						<span>Show only own playlists</span>
 					</label>
+				</li>
+				<li className="mt-2 border-gray-600 border-t pt-2">
+					<Link to="/debug" className="text-blue-400 hover:text-blue-300">
+						Diagnostics
+					</Link>
 				</li>
 			</ul>
 		)

--- a/src/components/layout/App.tsx
+++ b/src/components/layout/App.tsx
@@ -1,7 +1,8 @@
 import type React from 'react'
 import { useSelector } from 'react-redux'
-import { Route, Routes } from 'react-router'
+import { Route, Routes, useLocation } from 'react-router'
 import { Dashboard } from '~/pages/Dashboard'
+import Debug from '~/pages/Debug'
 import PlaylistsManager from '~/pages/Home'
 import NotFound from '~/pages/NotFound'
 import PlaylistRoute from '~/pages/PlaylistRoute'
@@ -22,6 +23,10 @@ import { Header } from './Header'
 const App: React.FC = () => {
 	const user = useSelector((s: State) => s.user)
 	const authChecking = useSelector((s: State) => s.auth.checking)
+	const location = useLocation()
+
+	// Reachable without auth so it can be read when the open/auth sequence hangs.
+	if (location.pathname === '/debug') return <Debug />
 
 	return (
 		<>

--- a/src/components/layout/StatusBar.tsx
+++ b/src/components/layout/StatusBar.tsx
@@ -2,6 +2,7 @@ import cn from 'classnames'
 import { startCase } from 'lodash/fp'
 import type React from 'react'
 import { useSelector } from 'react-redux'
+import { Link } from 'react-router-dom'
 import { UriLink } from '~/components/UriLink'
 import type { State } from '~/types'
 import { isPlaylist } from '~/utils'
@@ -43,6 +44,9 @@ export const StatusBar: React.FC = () => {
 				>
 					v{process.env.PACKAGE_VERSION}
 				</a>
+				<Link to="/debug" title="Diagnostics" className="opacity-70 hover:opacity-100">
+					🐞
+				</Link>
 			</span>
 
 			<span className="text-right">

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,6 +2,11 @@ import { library } from '@fortawesome/fontawesome-svg-core'
 import { fas } from '@fortawesome/free-solid-svg-icons'
 import { createRoot } from 'react-dom/client'
 import Root from './components/layout/Root'
+import { installDiagnostics } from './utils/diagnostics'
+
+// Install before anything else so the console tee + global error handlers
+// capture the whole open sequence (auth, cache hydration, playlist load).
+installDiagnostics()
 
 library.add(fas)
 

--- a/src/pages/Debug.tsx
+++ b/src/pages/Debug.tsx
@@ -1,0 +1,80 @@
+import { useState } from 'react'
+import { Link } from 'react-router-dom'
+import { clearDiagnostics, type DiagnosticEntry, type DiagnosticLevel, getDiagnostics } from '~/utils/diagnostics'
+
+const levelColor: Record<DiagnosticLevel, string> = {
+	info: 'text-gray-400',
+	warn: 'text-yellow-400',
+	error: 'text-red-400',
+	event: 'text-blue-400'
+}
+
+function formatTime(t: number) {
+	const d = new Date(t)
+	return `${d.toLocaleTimeString(undefined, { hour12: false })}.${String(d.getMilliseconds()).padStart(3, '0')}`
+}
+
+function gapMs(entries: DiagnosticEntry[], i: number) {
+	if (i === 0) return 0
+	return entries[i].t - entries[i - 1].t
+}
+
+const Debug: React.FC = () => {
+	const [entries, setEntries] = useState<DiagnosticEntry[]>(getDiagnostics)
+	const [copied, setCopied] = useState(false)
+
+	const refresh = () => setEntries(getDiagnostics())
+	const clear = () => {
+		clearDiagnostics()
+		setEntries([])
+	}
+	const copy = async () => {
+		const text = entries.map(e => `${formatTime(e.t)} [${e.level}] ${e.msg}`).join('\n')
+		try {
+			await navigator.clipboard.writeText(text)
+			setCopied(true)
+			setTimeout(() => setCopied(false), 1500)
+		} catch {
+			setCopied(false)
+		}
+	}
+
+	return (
+		<div className="p-4 text-sm">
+			<div className="mb-3 flex flex-wrap items-center gap-2">
+				<Link to="/" className="rounded bg-gray-700 px-3 py-1">
+					← Back
+				</Link>
+				<h2 className="mr-auto font-bold text-lg">Diagnostics ({entries.length})</h2>
+				<button type="button" className="rounded bg-gray-700 px-3 py-1" onClick={refresh}>
+					Refresh
+				</button>
+				<button type="button" className="rounded bg-gray-700 px-3 py-1" onClick={copy}>
+					{copied ? 'Copied!' : 'Copy all'}
+				</button>
+				<button type="button" className="rounded bg-red-800 px-3 py-1" onClick={clear}>
+					Clear
+				</button>
+			</div>
+			{entries.length === 0 ? (
+				<p className="text-gray-400">No diagnostics recorded.</p>
+			) : (
+				<ol className="space-y-1 font-mono text-xs">
+					{entries.map((e, i) => {
+						const gap = gapMs(entries, i)
+						return (
+							<li key={`${e.t}-${i}`} className="border-gray-800 border-b pb-1">
+								<span className="text-gray-500">{formatTime(e.t)}</span>{' '}
+								{gap >= 500 && <span className="text-orange-400">+{(gap / 1000).toFixed(1)}s </span>}
+								<span className={levelColor[e.level]}>[{e.level}]</span>{' '}
+								<span className="whitespace-pre-wrap break-words">{e.msg}</span>
+							</li>
+						)
+					})}
+				</ol>
+			)}
+		</div>
+	)
+}
+
+export default Debug

--- a/src/sagas/login.ts
+++ b/src/sagas/login.ts
@@ -40,8 +40,10 @@ function* getUserDetails(action: Action<typeof Actions.tokenAquired.type>) {
 	const token = action.payload
 
 	try {
+		console.info('getUserDetails: fetching /me')
 		const body = yield* call(() => spotifyFetch<SpotifyApi.UserObjectPublic>('me', {}, token))
 		if (body) {
+			console.info(`getUserDetails: /me resolved (${body.id})`)
 			// spotifyFetch may have refreshed the access token during /me — read
 			// the freshest token back from localStorage so we don't seed the
 			// store with an already-expired one.
@@ -103,11 +105,13 @@ function* loadUser(_: Action<typeof Actions.loadUser.type>) {
 
 	if (token) {
 		// authCheckDone is dispatched by the resulting getUserDetails
+		console.info('loadUser: using stored access token')
 		yield* put(Actions.tokenAquired(token, null))
 		return
 	}
 	if (refreshToken) {
 		try {
+			console.info('loadUser: refreshing access token')
 			const tokens = yield* call(refreshAccessToken, refreshToken)
 			storeTokens(tokens)
 			yield* put(Actions.tokenAquired(tokens.access_token, null))

--- a/src/sagas/playlists.ts
+++ b/src/sagas/playlists.ts
@@ -12,6 +12,7 @@ export function* playlistsSaga() {
 }
 
 function* getPlaylists() {
+	console.info('getPlaylists: fetching playlist list')
 	const playlists: SpotifyApi.ListOfCurrentUsersPlaylistsResponse['items'] = []
 	let response: SpotifyApi.ListOfCurrentUsersPlaylistsResponse | null
 	const limit = 50
@@ -33,6 +34,7 @@ function* getPlaylists() {
 	// the "In playlists" column then renders 0 for every track because the
 	// `tracks.lastFetched` filter excludes every other playlist.
 	yield* call(() => PlaylistCache.ready)
+	console.info(`getPlaylists: ${playlists.length} playlists fetched, cache ready`)
 	yield* put(Actions.playlistsFetched(playlists))
 }
 

--- a/src/sagas/tracks.ts
+++ b/src/sagas/tracks.ts
@@ -1,4 +1,4 @@
-import { all, call, put, select, takeEvery, takeLeading } from 'typed-redux-saga'
+import { all, call, put, type SagaGenerator, select, takeEvery, takeLeading } from 'typed-redux-saga'
 import { type Action, Actions } from '~/actions'
 import type { Nullable, Playlist, SongEntries, State, Track, URI } from '~/types'
 import { firebaseGet, idToUri, PlaylistCache, SongCache, toTrack } from '~/utils'
@@ -28,6 +28,7 @@ function* getAllTracks(action: Action<'FETCH_PLAYLISTS_SUCCESS'>) {
 	// session after a reload reads an empty Map and refetches every playlist
 	// from Spotify, even when fully cached locally.
 	yield* call(() => PlaylistCache.ready)
+	console.info(`getAllTracks: reconciling ${action.payload.length} playlists against cache`)
 
 	for (const playlist of action.payload) {
 		const existing = PlaylistCache.get(playlist.uri as URI<'playlist'>)
@@ -61,7 +62,7 @@ export function* getTrack(action: Action<'FETCH_TRACK'>) {
 	yield put(Actions.createNotification({ message: 'Error fetching track', type: 'error' }))
 }
 
-function* fetchPlays(uid: string | null | undefined, id: Playlist['id']): Generator<unknown, Nullable<SongEntries>> {
+function* fetchPlays(uid: string | null | undefined, id: Playlist['id']): SagaGenerator<Nullable<SongEntries>> {
 	if (!uid) return null
 	try {
 		return yield* call(() => firebaseGet(`users/${uid}/plays/spotify:playlist:${id}/`))

--- a/src/utils/diagnostics.ts
+++ b/src/utils/diagnostics.ts
@@ -1,0 +1,136 @@
+// In-PWA diagnostics. There are no devtools in an installed PWA, and a lot of
+// the app's failure paths only `console.warn`/`console.error` (refresh-token
+// transient failures, firebase retries, cache write errors, swallowed saga
+// errors). This tees those plus `console.info` milestones into a bounded ring
+// buffer persisted to localStorage, and catches global `error` /
+// `unhandledrejection` events. Read it at /debug — that route renders even when
+// unauthenticated, so it's reachable when the open/auth sequence itself hangs.
+
+const STORAGE_KEY = 'diagnostics_log'
+const MAX_ENTRIES = 300
+
+export type DiagnosticLevel = 'info' | 'warn' | 'error' | 'event'
+
+export interface DiagnosticEntry {
+	t: number
+	level: DiagnosticLevel
+	msg: string
+}
+
+let buffer: DiagnosticEntry[] | null = null
+let flushScheduled = false
+// Guards against re-entrancy: our flush failure handler must never feed itself.
+let inLog = false
+
+const original = {
+	info: console.info.bind(console),
+	warn: console.warn.bind(console),
+	error: console.error.bind(console)
+}
+
+function load(): DiagnosticEntry[] {
+	if (buffer) return buffer
+	try {
+		const raw = localStorage.getItem(STORAGE_KEY)
+		buffer = raw ? (JSON.parse(raw) as DiagnosticEntry[]) : []
+	} catch {
+		buffer = []
+	}
+	return buffer
+}
+
+function flush() {
+	flushScheduled = false
+	try {
+		localStorage.setItem(STORAGE_KEY, JSON.stringify(buffer ?? []))
+	} catch {
+		// Quota or serialization failure — drop silently; never recurse into logging.
+	}
+}
+
+function scheduleFlush() {
+	if (flushScheduled) return
+	flushScheduled = true
+	setTimeout(flush, 250)
+}
+
+function serialize(arg: unknown): string {
+	if (typeof arg === 'string') return arg
+	if (arg instanceof Error) return `${arg.name}: ${arg.message}${arg.stack ? `\n${arg.stack}` : ''}`
+	try {
+		return JSON.stringify(arg)
+	} catch {
+		return String(arg)
+	}
+}
+
+export function logDiagnostic(level: DiagnosticLevel, args: unknown[]) {
+	if (inLog) return
+	inLog = true
+	try {
+		const entries = load()
+		entries.push({ t: Date.now(), level, msg: args.map(serialize).join(' ') })
+		if (entries.length > MAX_ENTRIES) entries.splice(0, entries.length - MAX_ENTRIES)
+		scheduleFlush()
+	} catch {
+		// Never let diagnostics break the app.
+	} finally {
+		inLog = false
+	}
+}
+
+export function getDiagnostics(): DiagnosticEntry[] {
+	return [...load()]
+}
+
+export function clearDiagnostics() {
+	buffer = []
+	try {
+		localStorage.removeItem(STORAGE_KEY)
+	} catch {
+		// Ignore storage errors — the in-memory buffer is already cleared.
+	}
+}
+
+let installed = false
+
+export function installDiagnostics() {
+	if (installed) return
+	installed = true
+
+	console.info = (...args: unknown[]) => {
+		logDiagnostic('info', args)
+		original.info(...args)
+	}
+	console.warn = (...args: unknown[]) => {
+		logDiagnostic('warn', args)
+		original.warn(...args)
+	}
+	console.error = (...args: unknown[]) => {
+		logDiagnostic('error', args)
+		original.error(...args)
+	}
+
+	window.addEventListener('error', e => {
+		logDiagnostic('event', [
+			`window.onerror: ${e.message}`,
+			e.filename ? `@ ${e.filename}:${e.lineno}:${e.colno}` : ''
+		])
+	})
+	window.addEventListener('unhandledrejection', e => {
+		logDiagnostic('event', ['unhandledrejection:', e.reason])
+	})
+
+	// Persist promptly when the app is backgrounded/closed so a hang-then-kill
+	// (common on iOS PWAs) doesn't lose the last few entries.
+	const sync = () => {
+		if (flushScheduled) flush()
+	}
+	window.addEventListener('pagehide', sync)
+	window.addEventListener('beforeunload', sync)
+	document.addEventListener('visibilitychange', () => {
+		if (document.visibilityState === 'hidden') sync()
+	})
+
+	logDiagnostic('event', [`diagnostics installed — ${new Date().toISOString()}`])
+}


### PR DESCRIPTION
## Why

The app is slow/hangs on open and there's no way to see what's happening: an installed PWA has no devtools, and many of our failure paths only `console.warn`/`console.error` (refresh-token transients, firebase anon-auth retries, cache write errors, swallowed saga errors). We were guessing.

This gives us eyes inside the PWA so the next slow-open can be diagnosed from real data instead of speculation.

## What

- **`src/utils/diagnostics.ts`** — bounded ring buffer (300 entries) persisted to localStorage. Tees `console.info`/`warn`/`error` and catches global `error` / `unhandledrejection`. Flushes on `pagehide` / `beforeunload` / `visibilitychange→hidden` so an iOS hang-then-kill doesn't lose the tail. Re-entrancy- and quota-guarded so it can never break the app.
- **`src/pages/Debug.tsx`** — `/debug` page: timeline with `+Xs` gap markers (a stall shows up as a gap), Copy all / Clear / Refresh, Back link.
- **Reachability** — `/debug` short-circuits in `App.tsx` **before the auth gate**, so it renders even when login/open is hung. No address bar in a standalone PWA, so entry is via:
  - a discreet 🐞 in the footer status bar (renders in every auth state), and
  - a **Diagnostics** link in the settings modal (cog button, when logged in).
- **Breadcrumbs** — added `console.info` markers at the previously-silent open milestones: auth token path, `/me`, playlist list fetch, track reconciliation. These make the timeline pinpoint which phase stalls.

## Drive-by type fix

`fetchPlays` was annotated with a plain `Generator<...>` return type, so typed-redux-saga's `call` matched its "function returning a Generator" overload and typed `result.plays` as the generator object instead of its resolved value. Switched to `SagaGenerator<Nullable<SongEntries>>`. **`tsc --noEmit` is now fully clean** (it had this pre-existing error before).

## Scope

Diagnosis-only. It reveals *where* the open hangs; it does not yet fix it. The actual fixes (network timeout via `AbortController` on `spotifyFetch`, lazy `SongCache` hydration, on-demand track loading) are the follow-up once `/debug` confirms which suspect is real.

## Verification

- `yarn tsc --noEmit` — clean (fixes a pre-existing error)
- `yarn lint` (Biome) — clean
- `yarn stylelint` — clean
- `yarn build` — green
- `yarn test` — 43/43 pass

## How to use

Open the PWA, let it do a slow open, tap 🐞 (footer). Read the timeline — `+Xs` gaps show the stall. Likely tells: gap after `getUserDetails: fetching /me` (no fetch timeout exists), gap after `getPlaylists ... cache ready` (IndexedDB hydration), or a quiet stretch with SongCache warns (100k-key `SongCache` hydration — prime suspect).

🤖 Generated with [Claude Code](https://claude.com/claude-code)